### PR TITLE
[Rsbuild][Tests][Docs] Cover and document CDN support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Encore's real value to Symfony is two JSON files written into `outputPath`, cons
     ```json
     { "entrypoints": { "app": { "js": ["/build/runtime.js", "/build/app.js"], "css": ["/build/app.css"] } } }
     ```
-- **`manifest.json`** — maps logical filename -> versioned/hashed URL, for cache-busting. Keys are prefixed with `manifestKeyPrefix` (defaults to `publicPath` minus leading slash). When `publicPath` is an absolute CDN URL (contains `://`), `manifestKeyPrefix` must be set explicitly. Encore enforces this by throwing (`../webpack-encore/lib/config/path-util.ts`, `validatePublicPathAndManifestKeyPrefix`); **porting that guard is still TODO** — the current factory does not throw and would use the absolute URL as the key prefix. The `publicPath === null` branch in `assets/src/index.ts` is likewise dead (`publicPath` always defaults to `build/`).
+- **`manifest.json`** — maps logical filename -> versioned/hashed URL, for cache-busting. Keys are prefixed with `manifestKeyPrefix` (defaults to `publicPath` minus leading slash). When `publicPath` is an absolute CDN URL (contains `://`), `manifestKeyPrefix` must be set explicitly. Reprise ports the relevant half of Encore's `validatePublicPathAndManifestKeyPrefix` (`../webpack-encore/lib/config/path-util.js`) in `normalizeOptions`: an absolute `publicPath` without an explicit `manifestKeyPrefix` throws. Encore's second branch — rejecting a `publicPath` not contained in `outputPath` — is intentionally not ported: Reprise's `outputPath` (a filesystem dir) and `publicPath` (a URL prefix) are decoupled, so that heuristic would reject valid configs. CDN URLs in `entrypoints.json`/`manifest.json` are covered end-to-end by `assets/test/integration/cdn.test.ts`.
 
 ### Dev server (build mode vs serve mode)
 
@@ -94,5 +94,6 @@ Read-only clones under `.references/` (git-ignored) show how mature unplugins ar
 
 - ESM only, strict TypeScript, ES2017 target. Use the `node:` prefix for Node builtins.
 - New public options go in `assets/src/types.ts` with JSDoc; keep bundler adapters trivial.
+- Documentation: any user-facing feature ships with a short section in `doc/index.rst`, and that section shows **both** a Vite and an Rsbuild example (the two supported bundlers) — never document one without the other. Flip the matching `*(planned)*` marker in the feature lists (`doc/index.rst` and `README.md`) when the feature lands. Match the existing sections' natural voice; draft/polish the prose with the `natural-writing-editor` agent.
 - Commit messages: Symfony style `[<Scope>] <Short description>` — PascalCase scope, imperative mood, capitalized first word, no trailing period; combine scopes as `[A][B]` when a change spans several. E.g. `[Stimulus] Emit forward-slash local controller paths`, `[Docs] Frame Stimulus usage as the Encore experience`, `[CI] Cancel superseded runs with a concurrency group`. This is the convention used across Symfony UX and WebpackEncoreBundle — **not** Conventional Commits (no `feat:`/`fix:`/`chore:` prefixes).
 - Releases: the published npm package lives in `assets/` (`@symfony/reprise`); its `prepublishOnly` runs the `tsdown` build before publish.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Symfony Reprise covers only the Symfony-side glue the bundlers leave out:
 - 🔖 **Asset versioning**: content-hash cache busting, wired into the manifest
 - 🔥 **Dev server & HMR**: points Twig at the running Vite/Rsbuild server
 - 🧩 **Symfony UX / Stimulus**: registers `controllers.json` and local controllers, eager or lazy
-- 🌐 **CDN support**: absolute `publicPath` _(planned)_
+- 🌐 **CDN support**: serve built assets from an absolute `publicPath`
 - 🛡️ **Subresource Integrity**: SRI hashes in `entrypoints.json` _(planned)_
 - 📦 **Shared runtime chunk**: one runtime shared across entries _(planned)_
 

--- a/assets/src/rsbuild.ts
+++ b/assets/src/rsbuild.ts
@@ -57,7 +57,11 @@ export default function symfony(options?: Options): RsbuildPlugin {
                 // `/build/` prefix and the Vite path (whose `base` is likewise the publicPath). Without
                 // this the dev server serves at the origin root (`/`) while we advertise `/build/`, so
                 // every advertised URL 404s.
-                config.server.base = resolved.publicPath;
+                // `server.base` must be a slash-path (Rsbuild rejects anything else). An absolute
+                // (CDN) publicPath cannot be served by the local dev server, so fall back to the root;
+                // in dev the advertised URLs come from `resolvePublicPath` (which keeps an absolute
+                // publicPath as-is), so nothing is served under the CDN prefix locally anyway.
+                config.server.base = resolved.publicPath.includes('://') ? '/' : resolved.publicPath;
                 // Rsbuild's own config defaults `output.assetPrefix` to `'/'` before this hook runs
                 // (it is never left `undefined`), so `??=` would never apply ours — assign unconditionally.
                 // This drives the production build's asset URLs; in dev the serving path comes from

--- a/assets/test/core/options.test.ts
+++ b/assets/test/core/options.test.ts
@@ -30,6 +30,11 @@ describe('normalizeOptions', () => {
         expect(r.manifestKeyPrefix).toBe('build/');
     });
 
+    it('honors an explicit empty manifestKeyPrefix', () => {
+        const r = normalizeOptions({ publicPath: '/build/', manifestKeyPrefix: '' }, '/app');
+        expect(r.manifestKeyPrefix).toBe('');
+    });
+
     it('throws for an absolute publicPath without manifestKeyPrefix', () => {
         expect(() => normalizeOptions({ publicPath: 'https://cdn.example.com/x' }, '/app')).toThrow(
             /manifestKeyPrefix/

--- a/assets/test/integration/cdn.test.ts
+++ b/assets/test/integration/cdn.test.ts
@@ -1,0 +1,60 @@
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRsbuild } from '@rsbuild/core';
+import { build } from 'vite';
+import { describe, expect, it } from 'vitest';
+import SymfonyRsbuild from '../../src/rsbuild';
+import SymfonyVite from '../../src/vite';
+
+const fixture = join(import.meta.dirname, '../fixtures/basic');
+const CDN = 'https://cdn.example.com/assets/';
+const CDN_URL_RE = /^https:\/\/cdn\.example\.com\/assets\//;
+
+describe('absolute (CDN) publicPath', () => {
+    it('vite build emits CDN-prefixed URLs in entrypoints.json and manifest.json', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-cdn-vite-'));
+        await build({
+            root: fixture,
+            logLevel: 'silent',
+            build: {
+                emptyOutDir: true,
+                rollupOptions: { input: { app: join(fixture, 'app.js'), admin: join(fixture, 'admin.js') } },
+            },
+            plugins: [SymfonyVite({ outputPath: out, publicPath: CDN, manifestKeyPrefix: 'assets/' })],
+        });
+
+        const entry = JSON.parse(readFileSync(join(out, 'entrypoints.json'), 'utf8'));
+        expect(entry.publicPath).toBe(CDN);
+        expect(entry.entryPoints.app.js[0]).toMatch(/^https:\/\/cdn\.example\.com\/assets\/app-.*\.js$/);
+
+        const manifest = JSON.parse(readFileSync(join(out, 'manifest.json'), 'utf8'));
+        expect(manifest['assets/app.js']).toMatch(/^https:\/\/cdn\.example\.com\/assets\/app-.*\.js$/);
+        for (const value of Object.values(manifest)) {
+            expect(value).toMatch(CDN_URL_RE);
+        }
+    }, 30_000);
+
+    it('rsbuild build emits CDN-prefixed URLs in entrypoints.json and manifest.json', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-cdn-rsbuild-'));
+        const rsbuild = await createRsbuild({
+            cwd: fixture,
+            rsbuildConfig: {
+                mode: 'production',
+                source: { entry: { app: join(fixture, 'app.js'), admin: join(fixture, 'admin.js') } },
+                plugins: [SymfonyRsbuild({ outputPath: out, publicPath: CDN, manifestKeyPrefix: 'assets/' })],
+            },
+        });
+        await rsbuild.build();
+
+        const entry = JSON.parse(readFileSync(join(out, 'entrypoints.json'), 'utf8'));
+        expect(entry.publicPath).toBe(CDN);
+        expect(entry.entryPoints.app.js.some((u: string) => CDN_URL_RE.test(u))).toBe(true);
+
+        const manifest = JSON.parse(readFileSync(join(out, 'manifest.json'), 'utf8'));
+        expect(Object.keys(manifest).length).toBeGreaterThan(0);
+        for (const value of Object.values(manifest)) {
+            expect(value).toMatch(CDN_URL_RE);
+        }
+    }, 60_000);
+});

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,7 +21,7 @@ leave out:
 - **Dev server and HMR**: points Twig at the running Vite/Rsbuild server
 - **Symfony UX / Stimulus**: registers ``controllers.json`` and local
   controllers, eager or lazy
-- **CDN support**: absolute ``publicPath`` *(planned)*
+- **CDN support**: serve built assets from an absolute ``publicPath``
 - **Subresource Integrity**: SRI hashes in ``entrypoints.json`` *(planned)*
 - **Shared runtime chunk**: one runtime shared across entries *(planned)*
 
@@ -145,6 +145,67 @@ for Webpack's loader and needs an alias to the plain CSS build:
     })
 
 Check each package's own docs for this kind of tweak.
+
+Using a CDN
+-----------
+
+To serve your built assets from a CDN, set ``publicPath`` to the absolute CDN
+URL, for the production build only. In dev, the dev server serves assets
+directly, so keep the local ``/build/`` path there. Both bundlers expose the
+mode through the function form of their config, so switch on
+``command === 'build'``:
+
+.. code-block:: javascript
+
+    // vite.config.ts  (command is 'serve' or 'build')
+    import { defineConfig } from 'vite'
+    import Symfony from '@symfony/reprise/vite'
+
+    export default defineConfig(({ command }) => ({
+      plugins: [
+        Symfony({
+          publicPath:
+            command === 'build'
+              ? 'https://my-cool-app.com.global.prod.fastly.net/build/'
+              : '/build/',
+          manifestKeyPrefix: 'build/',
+        }),
+      ],
+    }))
+
+.. code-block:: javascript
+
+    // rsbuild.config.ts  (command is 'dev' or 'build')
+    import { defineConfig } from '@rsbuild/core'
+    import Symfony from '@symfony/reprise/rsbuild'
+
+    export default defineConfig(({ command }) => ({
+      plugins: [
+        Symfony({
+          publicPath:
+            command === 'build'
+              ? 'https://my-cool-app.com.global.prod.fastly.net/build/'
+              : '/build/',
+          manifestKeyPrefix: 'build/',
+        }),
+      ],
+    }))
+
+With an absolute ``publicPath``, ``manifestKeyPrefix`` is **required**: Reprise
+has no way to guess the right prefix for the ``manifest.json`` keys, and
+throws a clear error if it's missing. Keys stay logical, values point at the
+CDN:
+
+.. code-block:: json
+
+    {
+      "build/app.js": "https://my-cool-app.com.global.prod.fastly.net/build/app-1a2b3c.js"
+    }
+
+``entrypoints.json`` is rewritten the same way, so the ``<script>`` and
+``<link>`` tags render with CDN URLs. You still have to upload the built files
+to the CDN yourself, or set up origin pull. For a CDN subdirectory, include it
+in the URL (``https://my-cool-app.com.global.prod.fastly.net/awesome-website/build/``).
 
 .. _Vite: https://vite.dev/
 .. _Rsbuild: https://rsbuild.dev/

--- a/docs/superpowers/plans/2026-07-10-cdn-manifestkeyprefix-guard.md
+++ b/docs/superpowers/plans/2026-07-10-cdn-manifestkeyprefix-guard.md
@@ -1,0 +1,192 @@
+# CDN end-to-end coverage — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the test gap around absolute (CDN) `publicPath` and empty `manifestKeyPrefix`, reaching parity with Encore's `functional.js:256` and `config-generator.js:237`. Test-only; no production code changes.
+
+**Architecture:** Two additions — a new cross-bundler integration test that runs a real Vite build and a real Rsbuild build with a CDN `publicPath` and asserts CDN-prefixed URLs in `entrypoints.json`/`manifest.json`, plus one unit test asserting an explicit empty `manifestKeyPrefix` is preserved. Both characterize existing behaviour.
+
+**Tech Stack:** TypeScript (ESM, strict), vitest, `vite` + `@rsbuild/core` programmatic builds.
+
+## Global Constraints
+
+- ESM only, strict TypeScript, ES2017 target; `node:` prefix for Node builtins.
+- Tests live under `assets/test/`; run via `pnpm vitest run <file>` from the repo root; full suite via `pnpm test`.
+- Integration tests use `assets/test/fixtures/basic` (entries `app`, `admin`), a temp `outputPath` via `mkdtempSync`, and parse the emitted JSON — never the playground.
+- CDN config under test: `publicPath: 'https://cdn.example.com/assets/'` (trailing slash) + `manifestKeyPrefix: 'assets/'`.
+- Commit messages: Symfony style `[<Scope>] <Short description>`. Scopes: `[Tests]` for tests, `[Docs]` for AGENTS.md.
+- Spec: `docs/superpowers/specs/2026-07-10-cdn-manifestkeyprefix-guard-design.md`.
+
+**Note on TDD framing:** these are characterization tests for behaviour that already exists, so they are expected to PASS on first run. If a CDN integration test FAILS, that is a real bug — stop and report it before continuing.
+
+---
+
+### Task 1: Empty manifestKeyPrefix unit test
+
+**Files:**
+- Test: `assets/test/core/options.test.ts` (add one case to `describe('normalizeOptions')`)
+
+**Interfaces:**
+- Consumes: `normalizeOptions(options, cwd): ResolvedOptions` — unchanged.
+- Produces: nothing new.
+
+- [ ] **Step 1: Add the test**
+
+Insert after the "honors an explicit manifestKeyPrefix" test (`options.test.ts:31`):
+
+```ts
+    it('honors an explicit empty manifestKeyPrefix', () => {
+        const r = normalizeOptions({ publicPath: '/build/', manifestKeyPrefix: '' }, '/app');
+        expect(r.manifestKeyPrefix).toBe('');
+    });
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `pnpm vitest run assets/test/core/options.test.ts`
+Expected: PASS (current code keeps `''` because `options?.manifestKeyPrefix ?? null` preserves the empty string and skips derivation).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add assets/test/core/options.test.ts
+git commit -m "[Tests] Cover explicit empty manifestKeyPrefix"
+```
+
+---
+
+### Task 2: CDN end-to-end integration test (Vite + Rsbuild)
+
+**Files:**
+- Create: `assets/test/integration/cdn.test.ts`
+
+**Interfaces:**
+- Consumes: default exports `../../src/vite` (Vite plugin) and `../../src/rsbuild` (Rsbuild plugin), both `(options?: Options) => plugin`; `Options` includes `outputPath`, `publicPath`, `manifestKeyPrefix`.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the test file**
+
+Create `assets/test/integration/cdn.test.ts`:
+
+```ts
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRsbuild } from '@rsbuild/core';
+import { build } from 'vite';
+import { describe, expect, it } from 'vitest';
+import SymfonyRsbuild from '../../src/rsbuild';
+import SymfonyVite from '../../src/vite';
+
+const fixture = join(import.meta.dirname, '../fixtures/basic');
+const CDN = 'https://cdn.example.com/assets/';
+const CDN_URL_RE = /^https:\/\/cdn\.example\.com\/assets\//;
+
+describe('absolute (CDN) publicPath', () => {
+    it('vite build emits CDN-prefixed URLs in entrypoints.json and manifest.json', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-cdn-vite-'));
+        await build({
+            root: fixture,
+            logLevel: 'silent',
+            build: {
+                emptyOutDir: true,
+                rollupOptions: { input: { app: join(fixture, 'app.js'), admin: join(fixture, 'admin.js') } },
+            },
+            plugins: [SymfonyVite({ outputPath: out, publicPath: CDN, manifestKeyPrefix: 'assets/' })],
+        });
+
+        const entry = JSON.parse(readFileSync(join(out, 'entrypoints.json'), 'utf8'));
+        expect(entry.publicPath).toBe(CDN);
+        expect(entry.entryPoints.app.js[0]).toMatch(/^https:\/\/cdn\.example\.com\/assets\/app-.*\.js$/);
+
+        const manifest = JSON.parse(readFileSync(join(out, 'manifest.json'), 'utf8'));
+        expect(manifest['assets/app.js']).toMatch(/^https:\/\/cdn\.example\.com\/assets\/app-.*\.js$/);
+        for (const value of Object.values(manifest)) {
+            expect(value).toMatch(CDN_URL_RE);
+        }
+    }, 30_000);
+
+    it('rsbuild build emits CDN-prefixed URLs in entrypoints.json and manifest.json', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-cdn-rsbuild-'));
+        const rsbuild = await createRsbuild({
+            cwd: fixture,
+            rsbuildConfig: {
+                mode: 'production',
+                source: { entry: { app: join(fixture, 'app.js'), admin: join(fixture, 'admin.js') } },
+                plugins: [SymfonyRsbuild({ outputPath: out, publicPath: CDN, manifestKeyPrefix: 'assets/' })],
+            },
+        });
+        await rsbuild.build();
+
+        const entry = JSON.parse(readFileSync(join(out, 'entrypoints.json'), 'utf8'));
+        expect(entry.publicPath).toBe(CDN);
+        expect(entry.entryPoints.app.js.some((u: string) => CDN_URL_RE.test(u))).toBe(true);
+
+        const manifest = JSON.parse(readFileSync(join(out, 'manifest.json'), 'utf8'));
+        expect(Object.keys(manifest).length).toBeGreaterThan(0);
+        for (const value of Object.values(manifest)) {
+            expect(value).toMatch(CDN_URL_RE);
+        }
+    }, 60_000);
+});
+```
+
+- [ ] **Step 2: Run the new file**
+
+Run: `pnpm vitest run assets/test/integration/cdn.test.ts`
+Expected: PASS (2 tests). Absolute `publicPath` already flows through `joinUrl` in `buildEntrypoints`/`buildManifest`, so both files carry CDN URLs.
+If it FAILS: a real CDN bug — stop, diagnose (systematic-debugging), fix the production code, then re-run.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `pnpm test`
+Expected: PASS (was 66; now 69 — +1 unit from Task 1, +2 integration here).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add assets/test/integration/cdn.test.ts
+git commit -m "[Tests] Add CDN publicPath end-to-end build coverage for Vite and Rsbuild"
+```
+
+---
+
+### Task 3: Fix the stale AGENTS.md paragraph
+
+**Files:**
+- Modify: `AGENTS.md` (the "The Symfony integration contract" section)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Replace the stale sentences**
+
+In `AGENTS.md`, read the "The Symfony integration contract" section and replace:
+
+> Encore enforces this by throwing (`../webpack-encore/lib/config/path-util.ts`, `validatePublicPathAndManifestKeyPrefix`); **porting that guard is still TODO** — the current factory does not throw and would use the absolute URL as the key prefix. The `publicPath === null` branch in `assets/src/index.ts` is likewise dead (`publicPath` always defaults to `build/`).
+
+with:
+
+> Reprise ports the relevant half of Encore's `validatePublicPathAndManifestKeyPrefix` (`../webpack-encore/lib/config/path-util.js`) in `normalizeOptions`: an absolute `publicPath` (containing `://`) without an explicit `manifestKeyPrefix` throws. Encore's second branch — rejecting a `publicPath` not contained in `outputPath` — is intentionally not ported: Reprise's `outputPath` (a filesystem dir) and `publicPath` (a URL prefix) are decoupled, so that heuristic would reject valid configs. CDN URLs in `entrypoints.json`/`manifest.json` are covered end-to-end by `assets/test/integration/cdn.test.ts`.
+
+(If the surrounding wording differs slightly, keep it and swap only these sentences.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "[Docs] Clarify the manifestKeyPrefix guard and CDN coverage"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Empty manifestKeyPrefix parity → Task 1. ✓
+- CDN e2e (Vite + Rsbuild) → Task 2. ✓
+- Branch 2 rejection recorded, not implemented → no task (correct). ✓
+- AGENTS.md correction → Task 3. ✓
+
+**Placeholder scan:** No TBD/TODO; all test code shown in full. ✓
+
+**Type consistency:** Plugins imported as default exports `SymfonyVite`/`SymfonyRsbuild`, both `(options?: Options) => plugin`; assertions read `entry.publicPath`, `entry.entryPoints.app.js`, `manifest[...]` — matching the shapes in `vite-build.test.ts`/`rsbuild-build.test.ts`. ✓

--- a/docs/superpowers/specs/2026-07-10-cdn-manifestkeyprefix-guard-design.md
+++ b/docs/superpowers/specs/2026-07-10-cdn-manifestkeyprefix-guard-design.md
@@ -1,0 +1,61 @@
+# CDN polish — end-to-end coverage for absolute publicPath
+
+- **Date:** 2026-07-10 (revised same day)
+- **Status:** approved design, pre-implementation
+- **Scope:** JS plugin only (`@symfony/reprise`), test-only. First of the three roadmap "polish" items (CDN → SRI → shared runtime chunk).
+
+## Context
+
+The roadmap lists CDN / absolute `publicPath` as "mostly done in A1 — finalize". Absolute `publicPath` already works: `normalizeOptions` accepts it (requiring an explicit `manifestKeyPrefix`), and `buildEntrypoints`/`buildManifest` prefix every URL with it via `joinUrl`, so the emitted files carry CDN URLs. Both Vite (`config().base = publicPath`) and Rsbuild (`output.assetPrefix = publicPath`) propagate it.
+
+What "finalize" turns out to mean, after investigation, is **closing a test gap**, not adding code.
+
+## Rejected: porting Encore's second guard branch
+
+Encore's `validatePublicPathAndManifestKeyPrefix` (`../webpack-encore/lib/config/path-util.js`) has two throw branches when `manifestKeyPrefix` is unset:
+
+1. `publicPath` is absolute (`://`) → throw. **Already ported and tested** (`options.ts`, `options.test.ts:33`).
+2. `outputPath` does not contain `publicPath` (subdirectory heuristic) → throw with a suggestion.
+
+Branch 2 was implemented and **reverted**: it broke 15 integration tests. Root cause: those tests (and real Reprise usage) pass an `outputPath` that is an arbitrary temp/output directory decoupled from `publicPath` (a URL prefix). Encore couples the two only for its webpack-dev-server `getContentBase` document-root derivation — logic Reprise does not have (native dev server). In Reprise, `manifestKeyPrefix` derives from `publicPath` alone, independent of `outputPath`, so branch 2 rejects valid configs and protects nothing. It is intentionally not ported. Encore itself has no test asserting branch 2 throws — its subdirectory test (`config-generator.js:220`) sets `manifestKeyPrefix`, so branch 2 never fires; the expected pattern is "set `manifestKeyPrefix` for a subdir", which Reprise already supports (`options.test.ts:28`).
+
+## Coverage gap vs Encore
+
+Comparing the publicPath / manifestKeyPrefix / CDN slice (the rest of Encore's `config-generator.js` / `functional.js` covers bundler-native config — Sass, Babel, splitChunks, loaders — intentionally out of scope):
+
+| Encore test | Reprise |
+|---|---|
+| `config-generator.js`: normal publicPath → `build/` | ✅ `options.test.ts:23` |
+| `config-generator.js:220`: subdir + explicit manifestKeyPrefix | ✅ `options.test.ts:28` |
+| `config-generator.js:237`: empty manifestKeyPrefix | ⚠️ not asserted |
+| `functional.js:256`: `setPublicPath('http://…')` real build → CDN URLs in manifest/entrypoints | ❌ missing (only config-level) |
+
+This spec closes the two gaps.
+
+## Changes
+
+### 1. CDN end-to-end integration test (the real gap)
+
+New file `assets/test/integration/cdn.test.ts`, one test per bundler, mirroring the existing `vite-build.test.ts` / `rsbuild-build.test.ts` harness (fixture `test/fixtures/basic`, temp `outputPath`, parse emitted JSON). Config: `publicPath: 'https://cdn.example.com/assets/'` + `manifestKeyPrefix: 'assets/'`.
+
+Assertions:
+- `entrypoints.json` `publicPath` equals the CDN URL; entry `js[0]` matches `https://cdn.example.com/assets/…`.
+- `manifest.json` values are all CDN-prefixed. For Vite, the key `assets/app.js` maps to a CDN URL (Vite entry `logicalName` is `<name>.js`). For Rsbuild, assert only that keys exist and every value is CDN-prefixed (Rspack logical names differ; same convention as the existing rsbuild-build test).
+
+The trailing slash on `publicPath` avoids Vite's "base should end with /" normalization; it also matches Reprise's default `/build/`.
+
+**These characterize existing behaviour and are expected to pass on the first run.** A failure would mean a genuine CDN bug in a real build — in that case, stop and fix the bug before the tests land.
+
+### 2. Empty manifestKeyPrefix unit test (parity)
+
+Add to `assets/test/core/options.test.ts`: `normalizeOptions({ publicPath: '/build/', manifestKeyPrefix: '' }, '/app')` yields `manifestKeyPrefix === ''`. Current code preserves it (`options?.manifestKeyPrefix ?? null` keeps `''`, skipping derivation), so this too passes as-is — it locks the behaviour.
+
+## Docs
+
+Correct the stale `AGENTS.md` "Symfony integration contract" paragraph: it says the guard is TODO and mentions a dead `publicPath === null` branch in `index.ts`. Reword to state branch 1 is implemented and tested, branch 2 is intentionally not ported (outputPath/publicPath are decoupled in Reprise), and drop the dead-branch sentence (no such branch exists in the current `index.ts`).
+
+## Out of scope
+
+- Branch 2 subdir guard (rejected above).
+- Protocol-relative `//cdn` handling — Encore checks only `://`.
+- SRI and shared runtime chunk — separate spec + plan each.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

CDN support (absolute `publicPath`) already worked, but it had no end-to-end test coverage and no documentation. This branch closes that gap and, along the way, fixes a real bug the new test surfaced.

## Changes

- Added `assets/test/integration/cdn.test.ts`: a real Vite build and a real Rsbuild build with an absolute (CDN) `publicPath` plus `manifestKeyPrefix`, asserting CDN-prefixed URLs in both `entrypoints.json` and `manifest.json`. This reaches parity with Encore's `functional.js` CDN test.
- Fixed a bug the Rsbuild test surfaced: the Rsbuild adapter set `config.server.base` to the raw `publicPath`, which Rsbuild rejects when it's an absolute URL ("server.base should start with a slash"). It now falls back to `/` for an absolute `publicPath`. The local dev server can't serve from a CDN anyway, and the advertised dev URLs already come from `resolvePublicPath`.
- Added a unit test for an explicit empty `manifestKeyPrefix` (parity with Encore's `config-generator.js`).
- Investigated porting the second branch of Encore's `validatePublicPathAndManifestKeyPrefix` (throw when `outputPath` doesn't contain `publicPath`) and deliberately did not port it. In Reprise, `outputPath` (a filesystem directory) and `publicPath` (a URL prefix) are decoupled, so that heuristic rejects valid configs (it broke 15 tests when I tried it). Encore only needed the coupling for its webpack dev-server document root, which Reprise doesn't have. Recorded in the design spec and in `AGENTS.md`.
- Docs: new "Using a CDN" section in `doc/index.rst` with both a Vite and an Rsbuild example, showing how to switch `publicPath` on `command === 'build'` and why `manifestKeyPrefix` is required with an absolute `publicPath`. Flipped the CDN "(planned)" marker to shipped in `doc/index.rst` and `README.md`, and clarified the guard note in `AGENTS.md`.
- Added a convention to `AGENTS.md`: every user-facing feature ships with a `doc/index.rst` section showing both a Vite and an Rsbuild example.

## Testing

`pnpm test` (69 passing), `pnpm lint`, `pnpm fmt:check`.
