### PR TITLE
[CI] Test the suite against Node.js 22, 24 and 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
               run: pnpm run fmt:check
 
     test:
+        name: Node ${{ matrix.node-version }} on ${{ matrix.os }}
         runs-on: ${{ matrix.os }}
         permissions:
             contents: read
@@ -47,6 +48,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
+                node-version: ['22', '24', '26']
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
@@ -55,7 +57,7 @@ jobs:
             - name: Set node
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
-                  node-version-file: .nvmrc
+                  node-version: ${{ matrix.node-version }}
                   cache: pnpm
                   cache-dependency-path: pnpm-lock.yaml
             - name: Install

--- a/assets/package.json
+++ b/assets/package.json
@@ -47,7 +47,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=22.18"
+    "node": "^22.18.0 || ^24.11.0 || >=26.0"
   },
   "scripts": {
     "build": "tsdown",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "type": "module",
   "private": true,
   "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8",
+  "engines": {
+    "node": "^22.18.0 || ^24.11.0 || >=26.0"
+  },
   "scripts": {
     "build": "pnpm -C assets run build",
     "dev": "pnpm -C assets run dev",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The `test` job used to run on a single Node version pinned by `.nvmrc` (Node 22). This PR adds a version matrix instead, testing Node 22, 24 and 26 across the three OSes we already cover (ubuntu, windows, macos), with readable job names like "Node 24 on ubuntu-latest". The `lint` job keeps using `.nvmrc`, no need to matrix that one.

- CI now runs the test suite on Node 22 x 24 x 26 x {ubuntu, windows, macos}.
- `engines.node` in both the root `package.json` and `assets/package.json` (the published `@symfony/reprise`) now declares the same support, using the enumerated form Webpack Encore uses: `^22.18.0 || ^24.11.0 || >=26.0`. This is stricter than the previous `>=22.18` on the published package since it excludes the odd, non-LTS majors (23, 25). The root `package.json` had no `engines` field at all before.

This mirrors how `symfony/webpack-encore` declares and tests its supported Node versions. Ran the suite locally on Node 22.18.0 (the floor of the range) and it passes.
