### PR TITLE
[Integrity] Emit Subresource Integrity hashes in entrypoints.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ unplugin still earns its place for Vite and (upcoming) the Stimulus virtual modu
 
 ## The Symfony integration contract (the core of this project)
 
-Encore's real value to Symfony is two JSON files written into `outputPath`, consumed by WebpackEncoreBundle's Twig helpers (`encore_entry_script_tags()`, `encore_entry_link_tags()`, `asset()`). Generating these in Encore-compatible format is the primary work:
+Encore's real value to Symfony is two JSON files written into `outputPath`, consumed by Reprise's **own** Symfony bundle (`RepriseBundle`, the PHP side under `src/` — still a stub) via its Twig helpers that render the `<script>`/`<link>`/`asset()` tags. Reprise does **not** use `symfony/webpack-encore-bundle`. Generating these two files in Encore-compatible format is the primary work:
 
 - **`entrypoints.json`** — maps each entry name to its asset URLs grouped by type, in load order (runtime chunks before app chunks). Optional `integrity` section for SRI hashes.
     ```json
@@ -61,7 +61,7 @@ Encore's real value to Symfony is two JSON files written into `outputPath`, cons
 The plugin must behave differently depending on the bundler mode:
 
 - **Build mode** (`vite build`, `rsbuild build`): assets are written to `outputPath` with content hashes; `entrypoints.json`/`manifest.json` point at those files under `publicPath`.
-- **Serve/dev mode** (`vite`, `rsbuild dev`): the bundler's own dev server holds modules in memory and serves them over HTTP with native ESM + HMR. Here `entrypoints.json` must instead point at the dev server origin (e.g. `http://127.0.0.1:5173/build/app.js`) and inject the HMR client (`@vite/client`; React additionally needs the refresh preamble), so WebpackEncoreBundle's Twig tags load from the running dev server rather than from disk.
+- **Serve/dev mode** (`vite`, `rsbuild dev`): the bundler's own dev server holds modules in memory and serves them over HTTP with native ESM + HMR. Here `entrypoints.json` must instead point at the dev server origin (e.g. `http://127.0.0.1:5173/build/app.js`) and inject the HMR client (`@vite/client`; React additionally needs the refresh preamble), so RepriseBundle's Twig tags load from the running dev server rather than from disk.
 
 The dev server itself is native to Vite/Rsbuild — this plugin does not run one. Its only dev-server responsibility is detecting the mode (unplugin `meta`, or Vite's `configResolved` `command === 'serve'` vs `'build'`; Rsbuild/Rspack expose the same distinction) and emitting the dev-flavored `entrypoints.json` plus client injection. Encore's counterpart is `configureDevServerOptions()` (webpack-dev-server) in the reference `index.ts`, but that whole layer is replaced by the native dev server.
 
@@ -95,5 +95,6 @@ Read-only clones under `.references/` (git-ignored) show how mature unplugins ar
 - ESM only, strict TypeScript, ES2017 target. Use the `node:` prefix for Node builtins.
 - New public options go in `assets/src/types.ts` with JSDoc; keep bundler adapters trivial.
 - Documentation: any user-facing feature ships with a short section in `doc/index.rst`, and that section shows **both** a Vite and an Rsbuild example (the two supported bundlers) — never document one without the other. Flip the matching `*(planned)*` marker in the feature lists (`doc/index.rst` and `README.md`) when the feature lands. Match the existing sections' natural voice; draft/polish the prose with the `natural-writing-editor` agent.
-- Commit messages: Symfony style `[<Scope>] <Short description>` — PascalCase scope, imperative mood, capitalized first word, no trailing period; combine scopes as `[A][B]` when a change spans several. E.g. `[Stimulus] Emit forward-slash local controller paths`, `[Docs] Frame Stimulus usage as the Encore experience`, `[CI] Cancel superseded runs with a concurrency group`. This is the convention used across Symfony UX and WebpackEncoreBundle — **not** Conventional Commits (no `feat:`/`fix:`/`chore:` prefixes).
+- Tests: a functional/integration test for one bundler (Vite or Rsbuild) always ships with its equivalent for the other — never cover one bundler without the other, including the negative/off cases.
+- Commit messages: Symfony style `[<Scope>] <Short description>` — PascalCase scope, imperative mood, capitalized first word, no trailing period. A feature commit uses the feature's **own name** as the scope (e.g. `[Integrity]`, `[Manifest]`) and does **not** tack on `[Tests]` or `[Docs]` for the tests and docs it naturally includes; `[Tests]`/`[Docs]` are only for changes that are _exclusively_ tests or documentation. Combine scopes as `[A][B]` only when a change genuinely spans several distinct components. E.g. `[Stimulus] Emit forward-slash local controller paths`, `[Docs] Frame Stimulus usage as the Encore experience`, `[CI] Cancel superseded runs with a concurrency group`. This is the convention used across Symfony UX and WebpackEncoreBundle — **not** Conventional Commits (no `feat:`/`fix:`/`chore:` prefixes).
 - Releases: the published npm package lives in `assets/` (`@symfony/reprise`); its `prepublishOnly` runs the `tsdown` build before publish.

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Symfony Reprise covers only the Symfony-side glue the bundlers leave out:
 - 🔥 **Dev server & HMR**: points Twig at the running Vite/Rsbuild server
 - 🧩 **Symfony UX / Stimulus**: registers `controllers.json` and local controllers, eager or lazy
 - 🌐 **CDN support**: serve built assets from an absolute `publicPath`
-- 🛡️ **Subresource Integrity**: SRI hashes in `entrypoints.json` _(planned)_
+- 🛡️ **Subresource Integrity**: SRI hashes in `entrypoints.json`
 - 📦 **Shared runtime chunk**: one runtime shared across entries _(planned)_
 
 Vite and Rsbuild already handle **Sass/Less/PostCSS**, **TypeScript**, **JSX/Vue/Svelte**, **code splitting**, **content hashing**, **source maps**, **minification** and **HMR** on their own, so Symfony Reprise does not reimplement any of that.
 
-It generates the Encore-compatible `entrypoints.json` and `manifest.json` that [WebpackEncoreBundle](https://github.com/symfony/webpack-encore-bundle)'s Twig helpers (`encore_entry_script_tags()`, `encore_entry_link_tags()`) read, wires up the native dev server, and turns your Stimulus controllers into a running application.
+It generates the Encore-compatible `entrypoints.json` and `manifest.json` that Reprise's own Symfony bundle (`RepriseBundle`, still a stub) reads to render the `<script>` and `<link>` tags, wires up the native dev server, and turns your Stimulus controllers into a running application.
 
 [Read the documentation](doc/index.rst)

--- a/assets/src/core/format.ts
+++ b/assets/src/core/format.ts
@@ -14,7 +14,20 @@ export function buildEntrypoints(graph: NormalizedGraph, ctx: BuildContext): Ent
             dynamic: files.dynamic.map((f) => joinUrl(ctx.urlPrefix, f)),
         };
     }
-    return { isProd: ctx.isProd, devServer: ctx.devServer, publicPath: ctx.publicPath, entryPoints };
+    const out: EntrypointsJson = {
+        isProd: ctx.isProd,
+        devServer: ctx.devServer,
+        publicPath: ctx.publicPath,
+        entryPoints,
+    };
+    if (graph.integrity) {
+        // Re-key the per-file-name hashes by the same URLs that appear in the entry lists,
+        // so the Symfony side can look each one up by asset URL.
+        out.integrity = Object.fromEntries(
+            Object.entries(graph.integrity).map(([fileName, sri]) => [joinUrl(ctx.urlPrefix, fileName), sri])
+        );
+    }
+    return out;
 }
 
 export function buildManifest(graph: NormalizedGraph, ctx: BuildContext): ManifestJson {

--- a/assets/src/core/integrity.ts
+++ b/assets/src/core/integrity.ts
@@ -1,0 +1,45 @@
+import type { EntryFiles } from '../types';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Build a Subresource Integrity string for `content`: one `<algorithm>-<base64 digest>`
+ * token per algorithm, joined by spaces (the format browsers expect in an `integrity`
+ * attribute, and the one Webpack Encore writes into `entrypoints.json`).
+ */
+export function computeIntegrity(content: string | Uint8Array, algorithms: string[]): string {
+    return algorithms.map((algo) => `${algo}-${createHash(algo).update(content).digest('base64')}`).join(' ');
+}
+
+/**
+ * The distinct file names referenced by every entry, across all four buckets
+ * (js/css/preload/dynamic), in first-seen order. This is the set of emitted files
+ * that get an integrity hash.
+ */
+export function referencedFileNames(entryPoints: Record<string, EntryFiles>): string[] {
+    const seen = new Set<string>();
+    for (const files of Object.values(entryPoints)) {
+        for (const fileName of [...files.js, ...files.css, ...files.preload, ...files.dynamic]) {
+            seen.add(fileName);
+        }
+    }
+    return [...seen];
+}
+
+/**
+ * Compute the integrity of each file read from `outputPath` on disk, keyed by file name.
+ * Used by the Rspack path, whose `done` hook fires after the assets are emitted (like
+ * Encore, which reads the emitted files back). Bytes are hashed raw, so binary assets work.
+ */
+export function integrityFromDisk(
+    fileNames: string[],
+    outputPath: string,
+    algorithms: string[]
+): Record<string, string> {
+    const integrity: Record<string, string> = {};
+    for (const fileName of fileNames) {
+        integrity[fileName] = computeIntegrity(readFileSync(join(outputPath, fileName)), algorithms);
+    }
+    return integrity;
+}

--- a/assets/src/core/options.ts
+++ b/assets/src/core/options.ts
@@ -1,6 +1,11 @@
 import type { Options, ResolvedOptions, ResolvedStimulusOptions } from '../types';
 import * as path from 'node:path';
 
+function normalizeIntegrity(integrity: Options['integrity']): ResolvedOptions['integrity'] {
+    if (!integrity?.enabled) return undefined;
+    return { algorithms: integrity.algorithms?.length ? [...integrity.algorithms] : ['sha384'] };
+}
+
 function normalizeStimulus(stimulus: Options['stimulus'], cwd: string): ResolvedStimulusOptions | undefined {
     if (!stimulus) return undefined;
     const raw = typeof stimulus === 'string' ? { controllersJson: stimulus } : stimulus;
@@ -38,6 +43,7 @@ export function normalizeOptions(options: Options | undefined, cwd: string): Res
         manifestKeyPrefix,
         devServerOrigin: options?.devServerOrigin,
         stimulus: normalizeStimulus(options?.stimulus, cwd),
+        integrity: normalizeIntegrity(options?.integrity),
     };
 }
 

--- a/assets/src/index.ts
+++ b/assets/src/index.ts
@@ -1,11 +1,14 @@
 import type { UnpluginFactory } from 'unplugin';
-import type { BuildContext, Options } from './types';
+import type { BuildContext, NormalizedGraph, Options } from './types';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import * as process from 'node:process';
 import { createUnplugin } from 'unplugin';
 import { bundleToGraph, configToDevGraph } from './collectors/vite';
 import { resolveDevOrigin } from './core/dev-server';
 import { writeSymfonyFiles } from './core/emit';
 import { buildEntrypoints, buildManifest } from './core/format';
+import { integrityFromDisk, referencedFileNames } from './core/integrity';
 import { normalizeOptions, resolvePublicPath } from './core/options';
 import { generateControllersModule, STIMULUS_NOT_ENABLED_MESSAGE, VIRTUAL_CONTROLLERS_ID } from './core/stimulus';
 
@@ -15,6 +18,8 @@ const RESOLVED_VIRTUAL_ID = `\0${VIRTUAL_ID}`;
 export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, _meta) => {
     const resolved = normalizeOptions(options, process.cwd());
     let isDev = false;
+    // When SRI is on, entrypoints.json is finished in `writeBundle` (see below); stash what it needs.
+    let pendingIntegrity: { graph: NormalizedGraph; ctx: BuildContext } | null = null;
 
     return {
         name: '@symfony/reprise',
@@ -49,6 +54,25 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, _
                     fileName: 'manifest.json',
                     source: `${JSON.stringify(buildManifest(graph, ctx), null, 2)}\n`,
                 });
+                // SRI must hash the bytes that ship: Vite only finalizes chunks (replacing markers like
+                // `__VITE_PRELOAD__`) when writing to disk, so the in-memory bundle differs from the file.
+                // Defer to writeBundle (files on disk) and rewrite entrypoints.json with the integrity map.
+                if (resolved.integrity) pendingIntegrity = { graph, ctx };
+            },
+
+            writeBundle() {
+                if (!pendingIntegrity || !resolved.integrity) return;
+                const { graph, ctx } = pendingIntegrity;
+                pendingIntegrity = null;
+                graph.integrity = integrityFromDisk(
+                    referencedFileNames(graph.entryPoints),
+                    resolved.outputPath,
+                    resolved.integrity.algorithms
+                );
+                writeFileSync(
+                    join(resolved.outputPath, 'entrypoints.json'),
+                    `${JSON.stringify(buildEntrypoints(graph, ctx), null, 2)}\n`
+                );
             },
 
             configResolved(config) {

--- a/assets/src/rsbuild.ts
+++ b/assets/src/rsbuild.ts
@@ -6,6 +6,7 @@ import * as process from 'node:process';
 import { rspack } from '@rsbuild/core';
 import { statsToGraph } from './collectors/rspack';
 import { writeSymfonyFiles } from './core/emit';
+import { integrityFromDisk, referencedFileNames } from './core/integrity';
 import { buildEntrypoints, buildManifest } from './core/format';
 import { normalizeOptions, resolvePublicPath } from './core/options';
 import { generateControllersModule, STIMULUS_NOT_ENABLED_MESSAGE, VIRTUAL_CONTROLLERS_ID } from './core/stimulus';
@@ -131,6 +132,15 @@ export default function symfony(options?: Options): RsbuildPlugin {
                             manifestKeyPrefix: resolved.manifestKeyPrefix,
                         };
                         const graph = statsToGraph(stats.toJson({ assets: true, entrypoints: true }) as RspackStats);
+                        // SRI (build only): `done` fires after emit, so hash the files back off disk
+                        // (the same approach Encore takes). Dev serves changing in-memory assets, no hashes.
+                        if (!isDev && resolved.integrity) {
+                            graph.integrity = integrityFromDisk(
+                                referencedFileNames(graph.entryPoints),
+                                resolved.outputPath,
+                                resolved.integrity.algorithms
+                            );
+                        }
                         // In dev the manifest is empty: assets are served from the dev server, never looked
                         // up on disk by hash, so cache-busting is moot. entrypoints.json alone drives loading.
                         // Matches the Vite dev path (see `configureServer` in index.ts), which also writes `{}`.

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -84,7 +84,32 @@ export interface Options {
      */
     stimulus?: string | StimulusOptions;
 
+    /**
+     * Emit Subresource Integrity (SRI) hashes for the built assets.
+     *
+     * When enabled, `entrypoints.json` gains an `integrity` map (asset URL -> hash),
+     * which Reprise's Symfony bundle renders as `integrity="..."` on the script/link tags.
+     * Only applies to build mode; the dev server serves changing in-memory assets, so
+     * no hashes are emitted there.
+     *
+     * ```js
+     * // enable only for the production build (Vite exposes `command`)
+     * Symfony({ integrity: { enabled: command === 'build', algorithms: ['sha384'] } })
+     * ```
+     */
+    integrity?: IntegrityOptions;
+
     // singleRuntimeChunk?: boolean
+}
+
+/** Hash algorithm used for Subresource Integrity. */
+export type IntegrityAlgorithm = 'sha256' | 'sha384' | 'sha512';
+
+export interface IntegrityOptions {
+    /** Turn SRI on or off. Off by default. */
+    enabled: boolean;
+    /** Algorithms to hash each asset with. Default: `['sha384']`. */
+    algorithms?: IntegrityAlgorithm[];
 }
 
 export interface StimulusOptions {
@@ -112,6 +137,8 @@ export interface ResolvedOptions {
     manifestKeyPrefix: string;
     devServerOrigin?: string;
     stimulus?: ResolvedStimulusOptions;
+    /** Present (with a non-empty algorithm list) only when SRI is enabled. */
+    integrity?: { algorithms: string[] };
 }
 
 export interface EntryFiles {
@@ -134,6 +161,8 @@ export interface AssetEntry {
 export interface NormalizedGraph {
     entryPoints: Record<string, EntryFiles>;
     assets: AssetEntry[];
+    /** SRI hash per emitted file name; set by the collectors only when SRI is enabled. */
+    integrity?: Record<string, string>;
 }
 
 export interface BuildContext {
@@ -152,6 +181,8 @@ export interface EntrypointsJson {
     devServer: DevServer | null;
     publicPath: string;
     entryPoints: Record<string, EntryFiles>;
+    /** SRI hash per asset URL; present only in build mode with SRI enabled. */
+    integrity?: Record<string, string>;
 }
 
 export type ManifestJson = Record<string, string>;

--- a/assets/test/core/format.test.ts
+++ b/assets/test/core/format.test.ts
@@ -46,6 +46,21 @@ describe('buildEntrypoints', () => {
         expect(out.entryPoints.app.js).toEqual(['/build/app-a1b2.js']);
     });
 
+    it('emits a top-level integrity map keyed by URL when the graph carries hashes', () => {
+        const out = buildEntrypoints(
+            { ...graph, integrity: { 'app-a1b2.js': 'sha384-JS', 'app-c3d4.css': 'sha384-CSS' } },
+            ctx
+        );
+        expect(out.integrity).toEqual({
+            '/build/app-a1b2.js': 'sha384-JS',
+            '/build/app-c3d4.css': 'sha384-CSS',
+        });
+    });
+
+    it('omits integrity when the graph carries no hashes', () => {
+        expect(buildEntrypoints(graph, ctx).integrity).toBeUndefined();
+    });
+
     it('builds URLs from urlPrefix but emits the original publicPath field', () => {
         const devCtx: BuildContext = {
             isProd: false,

--- a/assets/test/core/integrity.test.ts
+++ b/assets/test/core/integrity.test.ts
@@ -1,0 +1,51 @@
+import type { EntryFiles } from '../../src/types';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { computeIntegrity, integrityFromDisk, referencedFileNames } from '../../src/core/integrity';
+
+describe('computeIntegrity', () => {
+    it('formats a single algorithm as `<algo>-<base64>`', () => {
+        expect(computeIntegrity('reprise', ['sha384'])).toBe(
+            'sha384-faAamSmmStfxJQ9skVshC6f5CFqO35HWc37M47/RU370OJxAaGp/EDpOhEtMqHU6'
+        );
+        expect(computeIntegrity('reprise', ['sha256'])).toBe('sha256-9HI/4mqcitIofBrwxywRV2OTHrfkKZSVAdGtr3AidrQ=');
+    });
+
+    it('joins multiple algorithms with a space, in the given order', () => {
+        expect(computeIntegrity('reprise', ['sha256', 'sha512'])).toBe(
+            'sha256-9HI/4mqcitIofBrwxywRV2OTHrfkKZSVAdGtr3AidrQ= sha512-lMCBX5XJ7xq9zWMR7zg7rQXzt0U1v/qX3vtUkCDkrBvOULn+UWCMFvf0hTGqKr+GMj+gTY5zzqQhISiHJlMDXg=='
+        );
+    });
+
+    it('hashes raw bytes (Uint8Array) the same as the equivalent string', () => {
+        expect(computeIntegrity(new TextEncoder().encode('reprise'), ['sha256'])).toBe(
+            computeIntegrity('reprise', ['sha256'])
+        );
+    });
+});
+
+describe('referencedFileNames', () => {
+    it('collects js/css/preload/dynamic across entries, deduped in first-seen order', () => {
+        const entryPoints: Record<string, EntryFiles> = {
+            app: { js: ['app.js'], css: ['app.css'], preload: ['vendor.js'], dynamic: ['lazy.js'] },
+            admin: { js: ['admin.js'], css: [], preload: ['vendor.js'], dynamic: [] },
+        };
+        expect(referencedFileNames(entryPoints)).toEqual(['app.js', 'app.css', 'vendor.js', 'lazy.js', 'admin.js']);
+    });
+});
+
+describe('integrityFromDisk', () => {
+    it('hashes each named file (including nested paths) read from the output directory', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'reprise-sri-'));
+        writeFileSync(join(dir, 'app.js'), 'reprise');
+        mkdirSync(dirname(join(dir, 'static/js/vendor.js')), { recursive: true });
+        writeFileSync(join(dir, 'static/js/vendor.js'), 'reprise');
+
+        expect(integrityFromDisk(['app.js', 'static/js/vendor.js'], dir, ['sha384'])).toEqual({
+            'app.js': 'sha384-faAamSmmStfxJQ9skVshC6f5CFqO35HWc37M47/RU370OJxAaGp/EDpOhEtMqHU6',
+            'static/js/vendor.js': 'sha384-faAamSmmStfxJQ9skVshC6f5CFqO35HWc37M47/RU370OJxAaGp/EDpOhEtMqHU6',
+        });
+    });
+});

--- a/assets/test/core/options.test.ts
+++ b/assets/test/core/options.test.ts
@@ -70,6 +70,32 @@ describe('normalizeOptions', () => {
             controllersDir: join('/app', 'assets/stimulus'),
         });
     });
+
+    it('leaves integrity undefined when not configured', () => {
+        expect(normalizeOptions(undefined, '/app').integrity).toBeUndefined();
+    });
+
+    it('leaves integrity undefined when explicitly disabled', () => {
+        expect(normalizeOptions({ integrity: { enabled: false } }, '/app').integrity).toBeUndefined();
+    });
+
+    it('defaults enabled integrity to the sha384 algorithm', () => {
+        expect(normalizeOptions({ integrity: { enabled: true } }, '/app').integrity).toEqual({
+            algorithms: ['sha384'],
+        });
+    });
+
+    it('honors explicit algorithms', () => {
+        expect(
+            normalizeOptions({ integrity: { enabled: true, algorithms: ['sha256', 'sha512'] } }, '/app').integrity
+        ).toEqual({ algorithms: ['sha256', 'sha512'] });
+    });
+
+    it('falls back to sha384 when enabled with an empty algorithm list', () => {
+        expect(normalizeOptions({ integrity: { enabled: true, algorithms: [] } }, '/app').integrity).toEqual({
+            algorithms: ['sha384'],
+        });
+    });
 });
 
 describe('resolvePublicPath', () => {

--- a/assets/test/integration/integrity.test.ts
+++ b/assets/test/integration/integrity.test.ts
@@ -1,0 +1,88 @@
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRsbuild } from '@rsbuild/core';
+import { build } from 'vite';
+import { describe, expect, it } from 'vitest';
+import { computeIntegrity } from '../../src/core/integrity';
+import SymfonyRsbuild from '../../src/rsbuild';
+import SymfonyVite from '../../src/vite';
+
+const fixture = join(import.meta.dirname, '../fixtures/basic');
+
+// Every URL in the integrity map must (a) look like an SRI hash and (b) match a fresh
+// hash of the actual emitted file — proving the plugin hashed the bytes it shipped.
+function assertIntegrityMatchesDisk(out: string, integrity: Record<string, string>): void {
+    expect(Object.keys(integrity).length).toBeGreaterThan(0);
+    for (const [url, sri] of Object.entries(integrity)) {
+        expect(url).toMatch(/^\/build\//);
+        expect(sri).toMatch(/^sha384-/);
+        const diskPath = join(out, url.replace(/^\/build\//, ''));
+        expect(computeIntegrity(readFileSync(diskPath), ['sha384'])).toBe(sri);
+    }
+}
+
+describe('Subresource Integrity', () => {
+    it('vite build writes an integrity map matching the emitted files', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-sri-vite-'));
+        await build({
+            root: fixture,
+            logLevel: 'silent',
+            build: {
+                emptyOutDir: true,
+                rollupOptions: { input: { app: join(fixture, 'app.js'), admin: join(fixture, 'admin.js') } },
+            },
+            plugins: [SymfonyVite({ outputPath: out, integrity: { enabled: true, algorithms: ['sha384'] } })],
+        });
+
+        const entry = JSON.parse(readFileSync(join(out, 'entrypoints.json'), 'utf8'));
+        expect(entry.integrity[entry.entryPoints.app.js[0]]).toMatch(/^sha384-/);
+        assertIntegrityMatchesDisk(out, entry.integrity);
+    }, 30_000);
+
+    it('rsbuild build writes an integrity map matching the emitted files', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-sri-rsbuild-'));
+        const rsbuild = await createRsbuild({
+            cwd: fixture,
+            rsbuildConfig: {
+                mode: 'production',
+                source: { entry: { app: join(fixture, 'app.js'), admin: join(fixture, 'admin.js') } },
+                plugins: [SymfonyRsbuild({ outputPath: out, integrity: { enabled: true, algorithms: ['sha384'] } })],
+            },
+        });
+        await rsbuild.build();
+
+        const entry = JSON.parse(readFileSync(join(out, 'entrypoints.json'), 'utf8'));
+        expect(entry.integrity[entry.entryPoints.app.js[0]]).toMatch(/^sha384-/);
+        assertIntegrityMatchesDisk(out, entry.integrity);
+    }, 60_000);
+
+    it('vite build without the option writes no integrity map', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-sri-off-vite-'));
+        await build({
+            root: fixture,
+            logLevel: 'silent',
+            build: { emptyOutDir: true, rollupOptions: { input: { app: join(fixture, 'app.js') } } },
+            plugins: [SymfonyVite({ outputPath: out })],
+        });
+
+        const entry = JSON.parse(readFileSync(join(out, 'entrypoints.json'), 'utf8'));
+        expect(entry.integrity).toBeUndefined();
+    }, 30_000);
+
+    it('rsbuild build without the option writes no integrity map', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-sri-off-rsbuild-'));
+        const rsbuild = await createRsbuild({
+            cwd: fixture,
+            rsbuildConfig: {
+                mode: 'production',
+                source: { entry: { app: join(fixture, 'app.js') } },
+                plugins: [SymfonyRsbuild({ outputPath: out })],
+            },
+        });
+        await rsbuild.build();
+
+        const entry = JSON.parse(readFileSync(join(out, 'entrypoints.json'), 'utf8'));
+        expect(entry.integrity).toBeUndefined();
+    }, 60_000);
+});

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -22,13 +22,13 @@ leave out:
 - **Symfony UX / Stimulus**: registers ``controllers.json`` and local
   controllers, eager or lazy
 - **CDN support**: serve built assets from an absolute ``publicPath``
-- **Subresource Integrity**: SRI hashes in ``entrypoints.json`` *(planned)*
+- **Subresource Integrity**: SRI hashes in ``entrypoints.json``
 - **Shared runtime chunk**: one runtime shared across entries *(planned)*
 
 It generates the Encore-compatible ``entrypoints.json`` and ``manifest.json``
-that WebpackEncoreBundle's Twig helpers (``encore_entry_script_tags()``,
-``encore_entry_link_tags()``) read, wires up the native dev server, and turns
-your Stimulus controllers into a running application.
+that Reprise's own Symfony bundle (``RepriseBundle``, still a stub) reads to
+render the ``<script>`` and ``<link>`` tags, wires up the native dev server,
+and turns your Stimulus controllers into a running application.
 
 Installation
 ------------
@@ -208,6 +208,67 @@ CDN:
 ``<link>`` tags render with CDN URLs. You still have to upload the built files
 to the CDN yourself, or set up origin pull. For a CDN subdirectory, include it
 in the URL (``https://my-cool-app.com.global.prod.fastly.net/awesome-website/build/``).
+
+Subresource Integrity
+---------------------
+
+When enabled, Reprise adds an ``integrity`` map to ``entrypoints.json`` (asset
+URL -> SRI hash). Reprise's Symfony bundle reads that map and renders
+``integrity="..."`` on the generated ``<script>`` and ``<link>`` tags, so the
+browser refuses any asset whose bytes were tampered with.
+
+The ``integrity`` option takes an object ``{ enabled, algorithms? }``. It only
+makes sense for the production build: the dev server serves changing
+in-memory assets, so no hashes are emitted in dev. As with the CDN example,
+toggle it with ``command === 'build'``:
+
+.. code-block:: javascript
+
+    // vite.config.ts  (command is 'serve' or 'build')
+    import { defineConfig } from 'vite'
+    import Symfony from '@symfony/reprise/vite'
+
+    export default defineConfig(({ command }) => ({
+      plugins: [
+        Symfony({
+          integrity: { enabled: command === 'build', algorithms: ['sha384'] },
+        }),
+      ],
+    }))
+
+.. code-block:: javascript
+
+    // rsbuild.config.ts  (command is 'dev' or 'build')
+    import { defineConfig } from '@rsbuild/core'
+    import Symfony from '@symfony/reprise/rsbuild'
+
+    export default defineConfig(({ command }) => ({
+      plugins: [
+        Symfony({
+          integrity: { enabled: command === 'build', algorithms: ['sha384'] },
+        }),
+      ],
+    }))
+
+``algorithms`` is optional and defaults to ``['sha384']``. Accepted values are
+``'sha256'``, ``'sha384'`` and ``'sha512'``. Passing several (e.g.
+``['sha256', 'sha512']``) writes multiple space-separated hashes per file,
+which the browser treats as "any one of these must match".
+
+The resulting ``entrypoints.json`` gets an extra ``integrity`` section:
+
+.. code-block:: json
+
+    {
+      "integrity": {
+        "/build/app-1a2b3c.js": "sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K...",
+        "/build/app-4d5e6f.css": "sha384-9ehJ4G8v3aQ2p1o0..."
+      }
+    }
+
+Hashes cover every referenced file in each entry (js, css, and
+preloaded/dynamic chunks), and since they're computed from the files actually
+written to disk, they stay correct through minification and hashing.
 
 .. _Vite: https://vite.dev/
 .. _Rsbuild: https://rsbuild.dev/

--- a/playground/package.json
+++ b/playground/package.json
@@ -2,10 +2,10 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "vite:dev": "nodemon -w '../assets/src/**/*.ts' -e .ts -x vite",
-    "vite:build": "nodemon -w '../assets/src/**/*.ts' -e .ts -x vite build",
-    "rsbuild:dev": "nodemon -w '../assets/src/**/*.ts' -e .ts -x rsbuild dev",
-    "rsbuild:build": "nodemon -w '../assets/src/**/*.ts' -e .ts -x rsbuild build"
+    "vite:dev": "vite",
+    "vite:build": "vite build",
+    "rsbuild:dev": "rsbuild dev",
+    "rsbuild:build": "rsbuild build"
   },
   "devDependencies": {
     "@hotwired/stimulus": "^3.0.0",

--- a/playground/rsbuild.config.ts
+++ b/playground/rsbuild.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
   plugins: [
     Symfony({
         stimulus: './assets/controllers.json',
+        integrity: {
+            enabled: true,
+            algorithms: ['sha256', 'sha384']
+        }
     }),
   ],
     resolve: {

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -19,6 +19,9 @@ export default defineConfig({
     Inspect(),
     Unplugin({
         stimulus: './assets/controllers.json',
+        integrity: {
+            enabled: true,
+        }
     }),
   ],
     resolve: {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to open an issue if none exists, explain below instead -->
| License       | MIT

Add an opt-in `integrity: { enabled, algorithms? }` option (default `['sha384']`)
that writes an `integrity` map (asset URL -> SRI hash) into entrypoints.json, for
Reprise's Symfony bundle (src/RepriseBundle.php, still a stub) to render as
integrity="..." on the script/link tags. This change is JS-only.

Hashes are computed from the files on disk after each bundler finishes emitting: the
Rspack `done` hook and a Vite `writeBundle` hook both read the emitted files back and
hash them. In-memory hashing does not work for Vite because it finalizes chunks (e.g.
replacing `__VITE_PRELOAD__`) only when writing to disk, so the shipped bytes differ
from the bundle. Every referenced file per entry (js/css/preload/dynamic) is covered.

Build only -- the dev server serves changing in-memory assets, so no hashes there.