### PR TITLE
[Docs] Drop the shared runtime chunk roadmap item

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ Encore wires this with `enableStimulusBridge(controllerJsonPath)` (reference `li
 
 That loader is webpack-only, so it must be reimplemented here as a bundler-agnostic **virtual module** (unplugin `resolveId`/`load`): parse `controllers.json`, resolve each third-party controller from its npm package (honoring enabled + eager/lazy + `autoimport`), glob the local `assets/controllers/` dir, and emit the code that registers them on the Stimulus app. Prior art: `vite-plugin-symfony`'s `virtual:symfony/controllers` module.
 
-Feature roadmap (see README): `entrypoints.json` (build + dev), `manifest.json`, asset versioning wired into the manifest, absolute/CDN `publicPath`, dev-server + HMR, SRI hashes, shared runtime chunk across entries, Symfony UX / Stimulus controllers.
+Feature roadmap (see README): `entrypoints.json` (build + dev), `manifest.json`, asset versioning wired into the manifest, absolute/CDN `publicPath`, dev-server + HMR, SRI hashes, Symfony UX / Stimulus controllers.
 
 ## Reference: the project being replaced
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Symfony Reprise covers only the Symfony-side glue the bundlers leave out:
 - 🧩 **Symfony UX / Stimulus**: registers `controllers.json` and local controllers, eager or lazy
 - 🌐 **CDN support**: serve built assets from an absolute `publicPath`
 - 🛡️ **Subresource Integrity**: SRI hashes in `entrypoints.json`
-- 📦 **Shared runtime chunk**: one runtime shared across entries _(planned)_
 
 Vite and Rsbuild already handle **Sass/Less/PostCSS**, **TypeScript**, **JSX/Vue/Svelte**, **code splitting**, **content hashing**, **source maps**, **minification** and **HMR** on their own, so Symfony Reprise does not reimplement any of that.
 

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -98,8 +98,6 @@ export interface Options {
      * ```
      */
     integrity?: IntegrityOptions;
-
-    // singleRuntimeChunk?: boolean
 }
 
 /** Hash algorithm used for Subresource Integrity. */

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,7 +23,6 @@ leave out:
   controllers, eager or lazy
 - **CDN support**: serve built assets from an absolute ``publicPath``
 - **Subresource Integrity**: SRI hashes in ``entrypoints.json``
-- **Shared runtime chunk**: one runtime shared across entries *(planned)*
 
 It generates the Encore-compatible ``entrypoints.json`` and ``manifest.json``
 that Reprise's own Symfony bundle (``RepriseBundle``, still a stub) reads to


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to open an issue if none exists, explain below instead -->
| License       | MIT

A single shared runtime chunk is a webpack/Rspack concept: Rollup emits native
ES modules with no bootstrap runtime, so there is nothing to share on the Vite
side. Forcing Rspack's `runtimeChunk: 'single'` would make the two bundlers
behave differently for no cross-bundler benefit -- and neither default fully
deduplicates shared code across entries anyway (Rspack embeds the runtime per
entry, Rollup inlines small shared modules). Both bundlers handle multi-entry
builds through their own code-splitting, so Reprise adds nothing here.

Remove the item from the README/doc/AGENTS roadmap lists and delete the stale
`singleRuntimeChunk` option stub.
