### PR TITLE
Read and resolve entrypoints.json in RepriseBundle

### DIFF
--- a/docs/adr/0001-packages-driven-asset-urls.md
+++ b/docs/adr/0001-packages-driven-asset-urls.md
@@ -1,0 +1,67 @@
+# 1. Packages-driven asset URL resolution
+
+- Status: Accepted
+- Date: 2026-07-11
+
+## Context
+
+The `@symfony/reprise` plugin currently writes `entrypoints.json` with **final** URLs
+(content-hashed filenames, prefixed with `publicPath`), and `RepriseBundle` would render the
+`<script>`/`<link>` tags from those URLs as-is.
+
+Emitting final URLs and skipping Symfony's asset component loses, at render time:
+
+- **`base_path`** — a build cannot be served under an arbitrary sub-directory
+  (`https://host/myapp/`); baked `/build/...` URLs 404 under `/myapp`.
+- **`base_urls`** — no runtime CDN selection or domain sharding.
+- **named packages** — `asset(path, 'package')`-style routing.
+- **consistency** — entry tags do not share the URL treatment `asset()` gives the app's other
+  assets (images, etc.).
+- **version not in the filename** — Webpack Encore lets the hash live in a query string
+  (`app.js?v=hash`, see symfony/webpack-encore#1266 and #1340), where only the manifest carries
+  the version. The general lesson: a URL is opaque, not a filesystem path, and the PHP side must
+  not assume where the version lives.
+
+## Decision
+
+Adopt Webpack Encore's model: **`Packages` (symfony/asset) drives final URL generation at render
+time.** The bundler is responsible only for producing the files (already content-hashed) and the
+manifest; `RepriseBundle` turns a reference into a URL via `Packages::getUrl()`
+(`base_path` + `base_urls` [+ named package]).
+
+Concretely — the "relative hashed paths" variant, chosen over the pure-Encore "logical keys +
+`JsonManifestVersionStrategy`" one because Vite/Rollup shared & dynamic chunks are anonymous
+(hashed names only, no natural logical key):
+
+- **`entrypoints.json` (build)** carries **relative, hashed** paths — `build/app-<hash>.js`, no
+  leading slash and no origin — instead of final URLs.
+- **`RepriseBundle`** resolves each reference through a Reprise asset package configured with the
+  app's `base_path`/`base_urls` but an **empty version strategy** (the filename is already
+  hashed).
+- **Dev / serve mode** keeps **absolute** dev-server-origin URLs
+  (`http://127.0.0.1:5173/build/app.js`); `Packages` returns absolute URLs unchanged, so
+  `base_path`/CDN correctly do not apply (the browser hits the dev server directly).
+- **SRI**: the `integrity` map must be keyed so the tag renderer can find each hash for the
+  reference it renders. SRI computation (hashing files on disk) is unaffected; only the map's key
+  changes.
+
+## Consequences
+
+This is cross-cutting, not a PHP-only addition:
+
+- **JS plugin** (`assets/src/core/format.ts`, collectors, the `cdn`/`build` integration tests):
+  build `entrypoints.json` changes from final URLs to relative hashed paths; SRI integrity keying
+  updates; the shipped tests that assert final URLs change.
+- **RepriseBundle**: the tag renderer (slice 2) resolves via `Packages`; config points at the
+  package(s); the integrity lookup is keyed to match. `EntrypointsLookup` (slice 1) is unaffected —
+  it returns whatever references the file holds.
+- **Docs**: the "Using a CDN" section reframes around `framework.assets`
+  (`base_path`/`base_urls`) instead of an absolute build-time `publicPath`.
+
+## Considered and rejected
+
+- **Keep self-describing final URLs.** Simplest, but loses everything under _Context_.
+- **Pure Encore (logical keys + `JsonManifestVersionStrategy`).** Most faithful and would support
+  query-string versioning, but requires inventing stable manifest keys for Vite's anonymous
+  shared/dynamic chunks, and query-string versioning is not expressible in Rollup output names
+  anyway.

--- a/src/Asset/DevServer.php
+++ b/src/Asset/DevServer.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Asset;
+
+use Symfony\Reprise\Exception\InvalidEntrypointsException;
+
+/**
+ * The dev-server section of a serve-mode entrypoints.json.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class DevServer
+{
+    public function __construct(
+        public readonly string $origin,
+        public readonly ?string $client,
+    ) {
+    }
+
+    /**
+     * @param array<mixed, mixed> $data the raw, untrusted decoded "devServer" section
+     */
+    public static function fromArray(array $data): self
+    {
+        $origin = $data['origin'] ?? null;
+        if (!\is_string($origin)) {
+            throw new InvalidEntrypointsException('The dev-server "origin" must be a string.');
+        }
+
+        $client = $data['client'] ?? null;
+        if (null !== $client && !\is_string($client)) {
+            throw new InvalidEntrypointsException('The dev-server "client" must be a string or null.');
+        }
+
+        return new self($origin, $client);
+    }
+}

--- a/src/Asset/Entry.php
+++ b/src/Asset/Entry.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Asset;
+
+use Symfony\Reprise\Exception\InvalidEntrypointsException;
+
+/**
+ * One entry's asset URLs, grouped by type, in load order.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class Entry
+{
+    /**
+     * @param list<string> $js
+     * @param list<string> $css
+     * @param list<string> $preload
+     * @param list<string> $dynamic
+     */
+    public function __construct(
+        public readonly array $js,
+        public readonly array $css,
+        public readonly array $preload,
+        public readonly array $dynamic,
+    ) {
+    }
+
+    /**
+     * @param array<mixed, mixed> $data the raw, untrusted decoded entry section
+     */
+    public static function fromArray(array $data, string $entryName): self
+    {
+        return new self(
+            self::stringList($data['js'] ?? [], $entryName, 'js'),
+            self::stringList($data['css'] ?? [], $entryName, 'css'),
+            self::stringList($data['preload'] ?? [], $entryName, 'preload'),
+            self::stringList($data['dynamic'] ?? [], $entryName, 'dynamic'),
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function stringList(mixed $value, string $entryName, string $key): array
+    {
+        if (!\is_array($value) || !array_is_list($value)) {
+            throw new InvalidEntrypointsException(\sprintf('The "%s" key of entry "%s" must be a list of strings.', $key, $entryName));
+        }
+
+        $strings = [];
+        foreach ($value as $item) {
+            if (!\is_string($item)) {
+                throw new InvalidEntrypointsException(\sprintf('The "%s" key of entry "%s" must contain only strings.', $key, $entryName));
+            }
+            $strings[] = $item;
+        }
+
+        return $strings;
+    }
+}

--- a/src/Asset/Entrypoints.php
+++ b/src/Asset/Entrypoints.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Asset;
+
+use Symfony\Reprise\Exception\InvalidEntrypointsException;
+
+/**
+ * The parsed contents of an entrypoints.json file emitted by the @symfony/reprise plugin.
+ *
+ * Unlike Webpack Encore's format, the file is self-describing: it carries the build mode
+ * (`isProd`/`devServer`), the `publicPath`, per-entry `preload`/`dynamic` chunks and, when
+ * SRI is enabled, an `integrity` map keyed by asset URL.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class Entrypoints
+{
+    /**
+     * @param array<string, Entry>  $entryPoints
+     * @param array<string, string> $integrity
+     */
+    public function __construct(
+        public readonly bool $isProd,
+        public readonly ?DevServer $devServer,
+        public readonly string $publicPath,
+        public readonly array $entryPoints,
+        public readonly array $integrity,
+    ) {
+    }
+
+    /**
+     * Validate and hydrate the raw decoded contents of an entrypoints.json file.
+     *
+     * The input is untrusted (whatever `json_decode()` produced), so it is deliberately typed
+     * loosely -- checking its shape is this method's job. Precision instead lives on the value
+     * object's properties and on the file-format documented on the class.
+     *
+     * @param array<mixed, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $isProd = $data['isProd'] ?? null;
+        if (!\is_bool($isProd)) {
+            throw new InvalidEntrypointsException('The "isProd" key must be a boolean.');
+        }
+
+        $publicPath = $data['publicPath'] ?? null;
+        if (!\is_string($publicPath)) {
+            throw new InvalidEntrypointsException('The "publicPath" key must be a string.');
+        }
+
+        $rawEntries = $data['entryPoints'] ?? null;
+        if (!\is_array($rawEntries)) {
+            throw new InvalidEntrypointsException('The "entryPoints" key must be an object.');
+        }
+
+        $entryPoints = [];
+        foreach ($rawEntries as $name => $files) {
+            if (!\is_array($files)) {
+                throw new InvalidEntrypointsException(\sprintf('Entry "%s" must be an object.', (string) $name));
+            }
+            $entryPoints[(string) $name] = Entry::fromArray($files, (string) $name);
+        }
+
+        $devServer = $data['devServer'] ?? null;
+        if (null !== $devServer && !\is_array($devServer)) {
+            throw new InvalidEntrypointsException('The "devServer" key must be an object or null.');
+        }
+
+        $rawIntegrity = $data['integrity'] ?? [];
+        if (!\is_array($rawIntegrity)) {
+            throw new InvalidEntrypointsException('The "integrity" key must be an object.');
+        }
+        $integrity = [];
+        foreach ($rawIntegrity as $url => $hash) {
+            if (!\is_string($url) || !\is_string($hash)) {
+                throw new InvalidEntrypointsException('The "integrity" map must map asset URLs to hash strings.');
+            }
+            $integrity[$url] = $hash;
+        }
+
+        return new self(
+            $isProd,
+            null !== $devServer ? DevServer::fromArray($devServer) : null,
+            $publicPath,
+            $entryPoints,
+            $integrity,
+        );
+    }
+}

--- a/src/Asset/EntrypointsLookup.php
+++ b/src/Asset/EntrypointsLookup.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Asset;
+
+use Symfony\Reprise\Exception\EntrypointNotFoundException;
+use Symfony\Reprise\Exception\EntrypointsFileNotFoundException;
+use Symfony\Reprise\Exception\InvalidEntrypointsException;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class EntrypointsLookup implements EntrypointsLookupInterface
+{
+    private bool $loaded = false;
+    private ?Entrypoints $entrypoints = null;
+
+    /**
+     * Files already returned this request, so a chunk shared by several entries
+     * (e.g. a preloaded vendor chunk) is emitted only once per page.
+     *
+     * @var list<string>
+     */
+    private array $returnedFiles = [];
+
+    public function __construct(
+        private readonly string $entrypointsPath,
+        private readonly bool $strictMode = true,
+    ) {
+    }
+
+    public function getJavaScriptFiles(string $entryName): array
+    {
+        return $this->getEntryFiles($entryName, 'js');
+    }
+
+    public function getCssFiles(string $entryName): array
+    {
+        return $this->getEntryFiles($entryName, 'css');
+    }
+
+    public function getPreloadFiles(string $entryName): array
+    {
+        return $this->getEntryFiles($entryName, 'preload');
+    }
+
+    public function getDynamicFiles(string $entryName): array
+    {
+        return $this->getEntryFiles($entryName, 'dynamic');
+    }
+
+    public function entryExists(string $entryName): bool
+    {
+        $entrypoints = $this->getEntrypoints();
+
+        return null !== $entrypoints && isset($entrypoints->entryPoints[$entryName]);
+    }
+
+    public function getIntegrityData(): array
+    {
+        $entrypoints = $this->getEntrypoints();
+
+        return null === $entrypoints ? [] : $entrypoints->integrity;
+    }
+
+    public function isProd(): bool
+    {
+        $entrypoints = $this->getEntrypoints();
+
+        return null !== $entrypoints && $entrypoints->isProd;
+    }
+
+    public function getDevServer(): ?DevServer
+    {
+        $entrypoints = $this->getEntrypoints();
+
+        return null === $entrypoints ? null : $entrypoints->devServer;
+    }
+
+    public function reset(): void
+    {
+        $this->returnedFiles = [];
+    }
+
+    /**
+     * @param 'js'|'css'|'preload'|'dynamic' $key
+     *
+     * @return list<string>
+     */
+    private function getEntryFiles(string $entryName, string $key): array
+    {
+        $entrypoints = $this->getEntrypoints();
+        if (null === $entrypoints) {
+            return [];
+        }
+
+        $entry = $entrypoints->entryPoints[$entryName] ?? null;
+        if (null === $entry) {
+            if ($this->strictMode) {
+                throw new EntrypointNotFoundException(\sprintf('Could not find the entry "%s" in "%s". Is the entry name correct?', $entryName, $this->entrypointsPath));
+            }
+
+            return [];
+        }
+
+        $files = match ($key) {
+            'js' => $entry->js,
+            'css' => $entry->css,
+            'preload' => $entry->preload,
+            'dynamic' => $entry->dynamic,
+        };
+
+        $newFiles = array_values(array_diff($files, $this->returnedFiles));
+        $this->returnedFiles = [...$this->returnedFiles, ...$newFiles];
+
+        return $newFiles;
+    }
+
+    private function getEntrypoints(): ?Entrypoints
+    {
+        if ($this->loaded) {
+            return $this->entrypoints;
+        }
+        $this->loaded = true;
+
+        if (!is_file($this->entrypointsPath)) {
+            if ($this->strictMode) {
+                throw new EntrypointsFileNotFoundException(\sprintf('Could not find the entrypoints file "%s". Did the assets get built?', $this->entrypointsPath));
+            }
+
+            return $this->entrypoints = null;
+        }
+
+        $decoded = json_decode((string) file_get_contents($this->entrypointsPath), true, flags: \JSON_THROW_ON_ERROR);
+        if (!\is_array($decoded)) {
+            throw new InvalidEntrypointsException(\sprintf('The entrypoints file "%s" must contain a JSON object.', $this->entrypointsPath));
+        }
+
+        return $this->entrypoints = Entrypoints::fromArray($decoded);
+    }
+}

--- a/src/Asset/EntrypointsLookupInterface.php
+++ b/src/Asset/EntrypointsLookupInterface.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Asset;
+
+/**
+ * Reads a single entrypoints.json file and resolves each entry's asset URLs.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+interface EntrypointsLookupInterface
+{
+    /**
+     * @return list<string>
+     */
+    public function getJavaScriptFiles(string $entryName): array;
+
+    /**
+     * @return list<string>
+     */
+    public function getCssFiles(string $entryName): array;
+
+    /**
+     * @return list<string>
+     */
+    public function getPreloadFiles(string $entryName): array;
+
+    /**
+     * @return list<string>
+     */
+    public function getDynamicFiles(string $entryName): array;
+
+    public function entryExists(string $entryName): bool;
+
+    /**
+     * @return array<string, string>
+     */
+    public function getIntegrityData(): array;
+
+    public function isProd(): bool;
+
+    public function getDevServer(): ?DevServer;
+
+    /**
+     * Clears the per-request deduplication state.
+     */
+    public function reset(): void;
+}

--- a/src/EventListener/ResetAssetsEventListener.php
+++ b/src/EventListener/ResetAssetsEventListener.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Reprise\Asset\EntrypointsLookupInterface;
+
+/**
+ * Clears the lookup's per-request deduplication state once the main request finishes,
+ * so a long-running worker (FrankenPHP, RoadRunner, ...) starts each request afresh.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class ResetAssetsEventListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly EntrypointsLookupInterface $entrypointsLookup,
+    ) {
+    }
+
+    public function onFinishRequest(FinishRequestEvent $event): void
+    {
+        if ($event->isMainRequest()) {
+            $this->entrypointsLookup->reset();
+        }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::FINISH_REQUEST => 'onFinishRequest'];
+    }
+}

--- a/src/Exception/EntrypointNotFoundException.php
+++ b/src/Exception/EntrypointNotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Exception;
+
+/**
+ * Thrown in strict mode when a requested entry is missing from the entrypoints.json file.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class EntrypointNotFoundException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Exception/EntrypointsFileNotFoundException.php
+++ b/src/Exception/EntrypointsFileNotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Exception;
+
+/**
+ * Thrown in strict mode when the entrypoints.json file cannot be found.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class EntrypointsFileNotFoundException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Exception;
+
+/**
+ * Marker interface implemented by every exception thrown by this bundle.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/src/Exception/InvalidEntrypointsException.php
+++ b/src/Exception/InvalidEntrypointsException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Exception;
+
+/**
+ * Thrown when an entrypoints.json file exists but its contents do not match the expected shape.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class InvalidEntrypointsException extends \UnexpectedValueException implements ExceptionInterface
+{
+}

--- a/src/RepriseBundle.php
+++ b/src/RepriseBundle.php
@@ -11,8 +11,57 @@
 
 namespace Symfony\Reprise;
 
+use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+use Symfony\Reprise\Asset\EntrypointsLookup;
+use Symfony\Reprise\Asset\EntrypointsLookupInterface;
+use Symfony\Reprise\EventListener\ResetAssetsEventListener;
 
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
 final class RepriseBundle extends AbstractBundle
 {
+    public function configure(DefinitionConfigurator $definition): void
+    {
+        $definition->rootNode()
+            ->children()
+                ->scalarNode('output_path')
+                    ->defaultValue('%kernel.project_dir%/public/build')
+                    ->info('Directory where the @symfony/reprise plugin writes entrypoints.json and manifest.json.')
+                ->end()
+                ->booleanNode('strict_mode')
+                    ->defaultTrue()
+                    ->info('Throw when the entrypoints.json file or a requested entry is missing.')
+                ->end()
+            ->end()
+        ;
+    }
+
+    /**
+     * @param array{output_path: string, strict_mode: bool} $config
+     */
+    public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
+    {
+        $services = $container->services();
+
+        $services->set('reprise.entrypoints_lookup', EntrypointsLookup::class)
+            ->args([
+                $config['output_path'].'/entrypoints.json',
+                $config['strict_mode'],
+            ])
+            ->tag('kernel.reset', ['method' => 'reset'])
+        ;
+
+        $services->alias(EntrypointsLookupInterface::class, 'reprise.entrypoints_lookup');
+
+        $services->set('reprise.reset_assets_listener', ResetAssetsEventListener::class)
+            ->args([service('reprise.entrypoints_lookup')])
+            ->tag('kernel.event_subscriber')
+        ;
+    }
 }

--- a/tests/Asset/EntrypointsLookupFunctionalTest.php
+++ b/tests/Asset/EntrypointsLookupFunctionalTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Tests\Asset;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Reprise\Asset\EntrypointsLookupInterface;
+use Symfony\Reprise\Tests\Kernel\FunctionalAppKernel;
+use Symfony\Reprise\Tests\Kernel\LookupConsumer;
+
+final class EntrypointsLookupFunctionalTest extends TestCase
+{
+    public function testTheLookupIsWiredFromConfigAndResolvesAnEntry()
+    {
+        $kernel = new FunctionalAppKernel(__DIR__.'/../fixtures/build');
+        $kernel->boot();
+
+        $lookup = $kernel->getContainer()->get(EntrypointsLookupInterface::class);
+
+        $this->assertInstanceOf(EntrypointsLookupInterface::class, $lookup);
+        $this->assertSame(['/build/app-a1b2.js'], $lookup->getJavaScriptFiles('app'));
+        $this->assertTrue($lookup->isProd());
+    }
+
+    public function testTheInterfaceIsAutowirableIntoUserServices()
+    {
+        $kernel = new FunctionalAppKernel(__DIR__.'/../fixtures/build');
+        $kernel->boot();
+
+        $consumer = $kernel->getContainer()->get(LookupConsumer::class);
+
+        $this->assertInstanceOf(LookupConsumer::class, $consumer);
+        $this->assertSame(['/build/app-a1b2.js'], $consumer->lookup->getJavaScriptFiles('app'));
+    }
+}

--- a/tests/Asset/EntrypointsLookupTest.php
+++ b/tests/Asset/EntrypointsLookupTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Tests\Asset;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Reprise\Asset\EntrypointsLookup;
+use Symfony\Reprise\Exception\EntrypointNotFoundException;
+use Symfony\Reprise\Exception\EntrypointsFileNotFoundException;
+use Symfony\Reprise\Exception\InvalidEntrypointsException;
+
+final class EntrypointsLookupTest extends TestCase
+{
+    private function lookup(bool $strictMode = true, string $file = 'build/entrypoints.json'): EntrypointsLookup
+    {
+        return new EntrypointsLookup(__DIR__.'/../fixtures/'.$file, $strictMode);
+    }
+
+    public function testResolvesAnEntrysFilesByType()
+    {
+        $lookup = $this->lookup();
+
+        $this->assertSame(['/build/app-a1b2.js'], $lookup->getJavaScriptFiles('app'));
+        $this->assertSame(['/build/app-c3d4.css'], $lookup->getCssFiles('app'));
+        $this->assertSame(['/build/shared-e5f6.js'], $lookup->getPreloadFiles('app'));
+        $this->assertSame(['/build/lazy-x.js'], $lookup->getDynamicFiles('app'));
+    }
+
+    public function testDeduplicatesSharedFilesAcrossCalls()
+    {
+        $lookup = $this->lookup();
+
+        // app pulls the shared preload chunk...
+        $this->assertSame(['/build/shared-e5f6.js'], $lookup->getPreloadFiles('app'));
+        // ...admin references the same chunk, but it must not be emitted twice on one page.
+        $this->assertSame([], $lookup->getPreloadFiles('admin'));
+        $this->assertSame(['/build/admin-99.js'], $lookup->getJavaScriptFiles('admin'));
+    }
+
+    public function testResetClearsDeduplicationState()
+    {
+        $lookup = $this->lookup();
+
+        $lookup->getPreloadFiles('app');
+        $lookup->reset();
+
+        $this->assertSame(['/build/shared-e5f6.js'], $lookup->getPreloadFiles('admin'));
+    }
+
+    public function testEntryExists()
+    {
+        $lookup = $this->lookup();
+
+        $this->assertTrue($lookup->entryExists('app'));
+        $this->assertFalse($lookup->entryExists('nope'));
+    }
+
+    public function testExposesModeAndIntegrity()
+    {
+        $lookup = $this->lookup();
+
+        $this->assertTrue($lookup->isProd());
+        $this->assertNull($lookup->getDevServer());
+        $this->assertSame('sha384-app', $lookup->getIntegrityData()['/build/app-a1b2.js']);
+    }
+
+    public function testExposesTheDevServerAndDevModeForAServeFlavouredFile()
+    {
+        $lookup = $this->lookup(file: 'dev/entrypoints.json');
+
+        $this->assertFalse($lookup->isProd());
+        $this->assertSame([], $lookup->getIntegrityData());
+        $this->assertSame(['http://127.0.0.1:5173/build/app.js'], $lookup->getJavaScriptFiles('app'));
+
+        $devServer = $lookup->getDevServer();
+        $this->assertNotNull($devServer);
+        $this->assertSame('http://127.0.0.1:5173', $devServer->origin);
+        $this->assertSame('vite', $devServer->client);
+    }
+
+    public function testThrowsWhenTheFileIsNotAJsonObject()
+    {
+        $this->expectException(InvalidEntrypointsException::class);
+
+        $this->lookup(file: 'malformed/entrypoints.json')->getJavaScriptFiles('app');
+    }
+
+    public function testStrictModeThrowsOnUnknownEntry()
+    {
+        $this->expectException(EntrypointNotFoundException::class);
+
+        $this->lookup()->getJavaScriptFiles('nope');
+    }
+
+    public function testNonStrictModeReturnsEmptyForUnknownEntry()
+    {
+        $this->assertSame([], $this->lookup(strictMode: false)->getJavaScriptFiles('nope'));
+    }
+
+    public function testStrictModeThrowsOnMissingFile()
+    {
+        $this->expectException(EntrypointsFileNotFoundException::class);
+
+        $this->lookup(file: 'does-not-exist/entrypoints.json')->getJavaScriptFiles('app');
+    }
+
+    public function testNonStrictModeIsQuietOnMissingFile()
+    {
+        $lookup = $this->lookup(strictMode: false, file: 'does-not-exist/entrypoints.json');
+
+        $this->assertSame([], $lookup->getJavaScriptFiles('app'));
+        $this->assertFalse($lookup->entryExists('app'));
+    }
+}

--- a/tests/Asset/EntrypointsTest.php
+++ b/tests/Asset/EntrypointsTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Tests\Asset;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Reprise\Asset\Entrypoints;
+use Symfony\Reprise\Exception\InvalidEntrypointsException;
+
+final class EntrypointsTest extends TestCase
+{
+    public function testFromArrayParsesEveryField()
+    {
+        $entrypoints = Entrypoints::fromArray([
+            'isProd' => true,
+            'devServer' => null,
+            'publicPath' => '/build/',
+            'entryPoints' => [
+                'app' => [
+                    'js' => ['/build/app.js'],
+                    'css' => ['/build/app.css'],
+                    'preload' => ['/build/shared.js'],
+                    'dynamic' => ['/build/lazy.js'],
+                ],
+            ],
+            'integrity' => ['/build/app.js' => 'sha384-xxx'],
+        ]);
+
+        $this->assertTrue($entrypoints->isProd);
+        $this->assertNull($entrypoints->devServer);
+        $this->assertSame('/build/', $entrypoints->publicPath);
+        $this->assertSame(['/build/app.js' => 'sha384-xxx'], $entrypoints->integrity);
+
+        $app = $entrypoints->entryPoints['app'];
+        $this->assertSame(['/build/app.js'], $app->js);
+        $this->assertSame(['/build/app.css'], $app->css);
+        $this->assertSame(['/build/shared.js'], $app->preload);
+        $this->assertSame(['/build/lazy.js'], $app->dynamic);
+    }
+
+    public function testFromArrayParsesTheDevServer()
+    {
+        $devServer = Entrypoints::fromArray([
+            'isProd' => false,
+            'devServer' => ['origin' => 'http://localhost:5173', 'client' => 'vite'],
+            'publicPath' => '/build/',
+            'entryPoints' => [],
+            'integrity' => [],
+        ])->devServer;
+
+        $this->assertNotNull($devServer);
+        $this->assertSame('http://localhost:5173', $devServer->origin);
+        $this->assertSame('vite', $devServer->client);
+    }
+
+    public function testFromArrayDefaultsMissingOptionalSections()
+    {
+        // A dev-flavoured file may omit `integrity`; entries may omit css/preload/dynamic.
+        $entrypoints = Entrypoints::fromArray([
+            'isProd' => false,
+            'devServer' => ['origin' => 'http://localhost:5173', 'client' => null],
+            'publicPath' => '/build/',
+            'entryPoints' => ['app' => ['js' => ['http://localhost:5173/build/app.js']]],
+        ]);
+
+        $this->assertSame([], $entrypoints->integrity);
+        $this->assertNotNull($entrypoints->devServer);
+        $this->assertNull($entrypoints->devServer->client);
+        $this->assertSame([], $entrypoints->entryPoints['app']->css);
+        $this->assertSame([], $entrypoints->entryPoints['app']->preload);
+        $this->assertSame([], $entrypoints->entryPoints['app']->dynamic);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    #[DataProvider('provideMalformedData')]
+    public function testFromArrayRejectsMalformedData(array $data)
+    {
+        $this->expectException(InvalidEntrypointsException::class);
+
+        Entrypoints::fromArray($data);
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public static function provideMalformedData(): iterable
+    {
+        $valid = ['isProd' => true, 'publicPath' => '/build/', 'entryPoints' => []];
+
+        yield 'isProd not a boolean' => [['publicPath' => '/build/', 'entryPoints' => []]];
+        yield 'publicPath not a string' => [['isProd' => true, 'publicPath' => 42, 'entryPoints' => []]];
+        yield 'entryPoints not an object' => [['isProd' => true, 'publicPath' => '/build/', 'entryPoints' => 'nope']];
+        yield 'entry not an object' => [[...$valid, 'entryPoints' => ['app' => 'nope']]];
+        yield 'entry js not a list' => [[...$valid, 'entryPoints' => ['app' => ['js' => ['key' => 'value']]]]];
+        yield 'entry js with a non-string' => [[...$valid, 'entryPoints' => ['app' => ['js' => [123]]]]];
+        yield 'entry css with a non-string' => [[...$valid, 'entryPoints' => ['app' => ['css' => [true]]]]];
+        yield 'devServer not an object' => [[...$valid, 'isProd' => false, 'devServer' => 'nope']];
+        yield 'devServer origin not a string' => [[...$valid, 'isProd' => false, 'devServer' => ['origin' => 42]]];
+        yield 'devServer client not a string' => [[...$valid, 'isProd' => false, 'devServer' => ['origin' => 'http://x', 'client' => 42]]];
+        yield 'integrity not an object' => [[...$valid, 'integrity' => 'nope']];
+        yield 'integrity value not a string' => [[...$valid, 'integrity' => ['/build/app.js' => 123]]];
+    }
+}

--- a/tests/EventListener/ResetAssetsEventListenerTest.php
+++ b/tests/EventListener/ResetAssetsEventListenerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Reprise\Asset\EntrypointsLookup;
+use Symfony\Reprise\EventListener\ResetAssetsEventListener;
+
+final class ResetAssetsEventListenerTest extends TestCase
+{
+    private function lookup(): EntrypointsLookup
+    {
+        return new EntrypointsLookup(__DIR__.'/../fixtures/build/entrypoints.json');
+    }
+
+    private function finishRequest(int $requestType): FinishRequestEvent
+    {
+        return new FinishRequestEvent($this->createStub(HttpKernelInterface::class), Request::create('/'), $requestType);
+    }
+
+    public function testResetsDeduplicationWhenTheMainRequestFinishes()
+    {
+        $lookup = $this->lookup();
+        $lookup->getPreloadFiles('app'); // marks the shared chunk as already returned
+
+        new ResetAssetsEventListener($lookup)->onFinishRequest($this->finishRequest(HttpKernelInterface::MAIN_REQUEST));
+
+        // After the reset the shared chunk is offered again to the next request.
+        $this->assertSame(['/build/shared-e5f6.js'], $lookup->getPreloadFiles('admin'));
+    }
+
+    public function testIgnoresSubRequests()
+    {
+        $lookup = $this->lookup();
+        $lookup->getPreloadFiles('app');
+
+        new ResetAssetsEventListener($lookup)->onFinishRequest($this->finishRequest(HttpKernelInterface::SUB_REQUEST));
+
+        // A sub-request finishing must NOT reset -- the shared chunk stays deduplicated.
+        $this->assertSame([], $lookup->getPreloadFiles('admin'));
+    }
+}

--- a/tests/Kernel/AppKernelTrait.php
+++ b/tests/Kernel/AppKernelTrait.php
@@ -11,11 +11,6 @@
 
 namespace Symfony\Reprise\Tests\Kernel;
 
-/**
- * @author Hugo Alliaume <hugo@alliau.me>
- *
- * @internal
- */
 trait AppKernelTrait
 {
     public function getCacheDir(): string

--- a/tests/Kernel/EmptyAppKernel.php
+++ b/tests/Kernel/EmptyAppKernel.php
@@ -15,11 +15,6 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Reprise\RepriseBundle;
 
-/**
- * @author Hugo Alliaume <hugo@alliau.me>
- *
- * @internal
- */
 class EmptyAppKernel extends Kernel
 {
     use AppKernelTrait;

--- a/tests/Kernel/FrameworkAppKernel.php
+++ b/tests/Kernel/FrameworkAppKernel.php
@@ -17,11 +17,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Reprise\RepriseBundle;
 
-/**
- * @author Hugo Alliaume <hugo@alliau.me>
- *
- * @internal
- */
 class FrameworkAppKernel extends Kernel
 {
     use AppKernelTrait;

--- a/tests/Kernel/FunctionalAppKernel.php
+++ b/tests/Kernel/FunctionalAppKernel.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Tests\Kernel;
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Reprise\Asset\EntrypointsLookupInterface;
+use Symfony\Reprise\RepriseBundle;
+
+/**
+ * A framework kernel wired with a given Reprise `output_path`, exposing the lookup service
+ * publicly so functional tests can fetch it from the container.
+ */
+final class FunctionalAppKernel extends Kernel implements CompilerPassInterface
+{
+    use AppKernelTrait;
+
+    public function __construct(private readonly string $outputPath)
+    {
+        parent::__construct('test', true);
+    }
+
+    public function registerBundles(): iterable
+    {
+        return [new FrameworkBundle(), new RepriseBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        $loader->load(function (ContainerBuilder $container): void {
+            $container->loadFromExtension('framework', [
+                'secret' => '$ecret',
+                'test' => true,
+                'http_method_override' => false,
+            ]);
+            $container->loadFromExtension('reprise', [
+                'output_path' => $this->outputPath,
+            ]);
+
+            // A user-land service autowiring the lookup by its interface.
+            $container->register(LookupConsumer::class)
+                ->setAutowired(true)
+                ->setPublic(true);
+        });
+    }
+
+    protected function build(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass($this);
+    }
+
+    public function process(ContainerBuilder $container): void
+    {
+        $container->getAlias(EntrypointsLookupInterface::class)->setPublic(true);
+    }
+}

--- a/tests/Kernel/LookupConsumer.php
+++ b/tests/Kernel/LookupConsumer.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Tests\Kernel;
+
+use Symfony\Reprise\Asset\EntrypointsLookupInterface;
+
+/**
+ * A user-land-style service that receives the lookup autowired by its interface.
+ */
+final class LookupConsumer
+{
+    public function __construct(
+        public readonly EntrypointsLookupInterface $lookup,
+    ) {
+    }
+}

--- a/tests/RepriseBundleTest.php
+++ b/tests/RepriseBundleTest.php
@@ -29,7 +29,7 @@ final class RepriseBundleTest extends TestCase
     }
 
     #[DataProvider('provideKernels')]
-    public function testBundleBootsInAKernel(Kernel $kernel): void
+    public function testBundleBootsInAKernel(Kernel $kernel)
     {
         $kernel->boot();
 

--- a/tests/fixtures/build/entrypoints.json
+++ b/tests/fixtures/build/entrypoints.json
@@ -1,0 +1,23 @@
+{
+    "isProd": true,
+    "devServer": null,
+    "publicPath": "/build/",
+    "entryPoints": {
+        "app": {
+            "js": ["/build/app-a1b2.js"],
+            "css": ["/build/app-c3d4.css"],
+            "preload": ["/build/shared-e5f6.js"],
+            "dynamic": ["/build/lazy-x.js"]
+        },
+        "admin": {
+            "js": ["/build/admin-99.js"],
+            "css": [],
+            "preload": ["/build/shared-e5f6.js"],
+            "dynamic": []
+        }
+    },
+    "integrity": {
+        "/build/app-a1b2.js": "sha384-app",
+        "/build/shared-e5f6.js": "sha384-shared"
+    }
+}

--- a/tests/fixtures/dev/entrypoints.json
+++ b/tests/fixtures/dev/entrypoints.json
@@ -1,0 +1,13 @@
+{
+    "isProd": false,
+    "devServer": { "origin": "http://127.0.0.1:5173", "client": "vite" },
+    "publicPath": "/build/",
+    "entryPoints": {
+        "app": {
+            "js": ["http://127.0.0.1:5173/build/app.js"],
+            "css": [],
+            "preload": [],
+            "dynamic": []
+        }
+    }
+}

--- a/tests/fixtures/malformed/entrypoints.json
+++ b/tests/fixtures/malformed/entrypoints.json
@@ -1,0 +1,1 @@
+"not a json object"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This is the read foundation of `RepriseBundle` (until now an empty stub): it reads and resolves the `entrypoints.json` the JS plugin emits. No rendering yet -- Twig tags and preload are separate slices coming later.

Adds:

- Value objects for the self-describing `entrypoints.json` (`Entrypoints`, `Entry`, `DevServer`) with validating `fromArray()` factories. Malformed input is rejected with a clear `InvalidEntrypointsException`.
- `EntrypointsLookup` (behind `EntrypointsLookupInterface`): resolves an entry's js/css/preload/dynamic URLs, deduplicates a chunk shared by several entries within one request (so a shared file isn't emitted twice on one page), exposes the integrity map and the build mode (isProd / dev server), and supports strict and non-strict lookups.
- `ResetAssetsEventListener`, which clears the per-request dedup state when the main request finishes. Needed for long-running workers like FrankenPHP or RoadRunner, where state would otherwise leak across requests.
- Bundle config (`output_path`, `strict_mode`) and service wiring. The interface is autowirable, so user code can inject it directly, for example to render an entry several times or for PDF generation, calling `reset()` between renders.

Also records ADR 0001 (`doc/adr/0001-packages-driven-asset-urls.md`): asset URLs will be resolved through Symfony's asset `Packages` at render time (base_path + base_urls), mirroring Webpack Encore, rather than the JS plugin emitting final URLs. The upcoming tag-renderer slice builds on that decision, and it means the JS plugin's `entrypoints.json` output format will change (relative hashed paths instead of resolved URLs). The reader added here isn't affected: it just returns whatever references the file holds.

Testing: 32 tests, 100% line/method/class coverage on the new code. PHPStan max and PHP-CS-Fixer clean.
