### PR TITLE
[Twig] Render asset tags from entrypoints.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@ Symfony Reprise covers only the Symfony-side glue the bundlers leave out:
 - 🔖 **Asset versioning**: content-hash cache busting, wired into the manifest
 - 📁 **File copy**: copy static files (images, fonts…) into the build, keyed in the manifest
 - 🔥 **Dev server & HMR**: points Twig at the running Vite/Rsbuild server
+- 🏷️ **Twig tag rendering**: `reprise_entry_script_tags`/`reprise_entry_link_tags` render straight from `entrypoints.json`
 - 🧩 **Symfony UX / Stimulus**: registers `controllers.json` and local controllers, eager or lazy
 - 🌐 **CDN support**: serve built assets from an absolute `publicPath`
 - 🛡️ **Subresource Integrity**: SRI hashes in `entrypoints.json`
 
 Vite and Rsbuild already handle **Sass/Less/PostCSS**, **TypeScript**, **JSX/Vue/Svelte**, **code splitting**, **content hashing**, **source maps**, **minification** and **HMR** on their own, so Symfony Reprise does not reimplement any of that.
 
-It generates the Encore-compatible `entrypoints.json` and `manifest.json` that Reprise's own Symfony bundle (`RepriseBundle`, still a stub) reads to render the `<script>` and `<link>` tags, wires up the native dev server, and turns your Stimulus controllers into a running application.
+It generates the Encore-compatible `entrypoints.json` and `manifest.json` that Reprise's own Symfony bundle (`RepriseBundle`) reads to render the `<script>` and `<link>` tags, wires up the native dev server, and turns your Stimulus controllers into a running application.
 
 [Read the documentation](doc/index.rst)

--- a/assets/src/core/format.ts
+++ b/assets/src/core/format.ts
@@ -4,14 +4,20 @@ export function joinUrl(prefix: string, name: string): string {
     return prefix.endsWith('/') ? prefix + name : `${prefix}/${name}`;
 }
 
+function toReference(prefix: string, name: string): string {
+    // Docroot-relative reference (ADR 0001): a build URL like `/build/app-<hash>.js` becomes
+    // `build/app-<hash>.js`; an absolute dev-server URL has no leading slash and is unchanged.
+    return joinUrl(prefix, name).replace(/^\//, '');
+}
+
 export function buildEntrypoints(graph: NormalizedGraph, ctx: BuildContext): EntrypointsJson {
     const entryPoints: Record<string, EntryFiles> = {};
     for (const [name, files] of Object.entries(graph.entryPoints)) {
         entryPoints[name] = {
-            js: files.js.map((f) => joinUrl(ctx.urlPrefix, f)),
-            css: files.css.map((f) => joinUrl(ctx.urlPrefix, f)),
-            preload: files.preload.map((f) => joinUrl(ctx.urlPrefix, f)),
-            dynamic: files.dynamic.map((f) => joinUrl(ctx.urlPrefix, f)),
+            js: files.js.map((f) => toReference(ctx.urlPrefix, f)),
+            css: files.css.map((f) => toReference(ctx.urlPrefix, f)),
+            preload: files.preload.map((f) => toReference(ctx.urlPrefix, f)),
+            dynamic: files.dynamic.map((f) => toReference(ctx.urlPrefix, f)),
         };
     }
     const out: EntrypointsJson = {
@@ -21,10 +27,10 @@ export function buildEntrypoints(graph: NormalizedGraph, ctx: BuildContext): Ent
         entryPoints,
     };
     if (graph.integrity) {
-        // Re-key the per-file-name hashes by the same URLs that appear in the entry lists,
-        // so the Symfony side can look each one up by asset URL.
+        // Re-key the per-file-name hashes by the same references that appear in the entry lists,
+        // so the Symfony side can look each one up by asset reference.
         out.integrity = Object.fromEntries(
-            Object.entries(graph.integrity).map(([fileName, sri]) => [joinUrl(ctx.urlPrefix, fileName), sri])
+            Object.entries(graph.integrity).map(([fileName, sri]) => [toReference(ctx.urlPrefix, fileName), sri])
         );
     }
     return out;

--- a/assets/src/index.ts
+++ b/assets/src/index.ts
@@ -8,7 +8,7 @@ import { bundleToGraph, configToDevGraph } from './collectors/vite';
 import { copyManifest, resolveCopyFiles, writeCopyFiles } from './core/copy';
 import { resolveDevOrigin } from './core/dev-server';
 import { writeSymfonyFiles } from './core/emit';
-import { buildEntrypoints, buildManifest } from './core/format';
+import { buildEntrypoints, buildManifest, joinUrl } from './core/format';
 import { integrityFromDisk, referencedFileNames } from './core/integrity';
 import { normalizeOptions, resolvePublicPath } from './core/options';
 import { generateControllersModule, STIMULUS_NOT_ENABLED_MESSAGE, VIRTUAL_CONTROLLERS_ID } from './core/stimulus';
@@ -124,11 +124,15 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, _
                     });
                     server.config.server.origin = origin; // keep Vite's internal URL rewriting in sync
 
+                    // Vite serves its HMR client under `base` (our publicPath), so the client URL is
+                    // `<origin><publicPath>@vite/client` — not `<origin>/@vite/client`. Emit the full URL
+                    // so the Symfony side injects it verbatim.
+                    const urlPrefix = resolvePublicPath(resolved.publicPath, origin);
                     const ctx: BuildContext = {
                         isProd: false,
-                        devServer: { origin, client: 'vite' },
+                        devServer: { origin, client: joinUrl(urlPrefix, '@vite/client') },
                         publicPath: resolved.publicPath,
-                        urlPrefix: resolvePublicPath(resolved.publicPath, origin),
+                        urlPrefix,
                         manifestKeyPrefix: resolved.manifestKeyPrefix,
                     };
                     try {

--- a/assets/src/rsbuild.ts
+++ b/assets/src/rsbuild.ts
@@ -69,6 +69,39 @@ export default function symfony(options?: Options): RsbuildPlugin {
                 // This drives the production build's asset URLs; in dev the serving path comes from
                 // `server.base` above.
                 config.output.assetPrefix = resolved.publicPath;
+                // Standardise on ESM so the tags render as `<script type="module">` like Vite.
+                config.output.module = true;
+
+                // HMR + lazy-compilation client. Rspack compiles the client INTO the bundle, and by
+                // default it derives its WebSocket URL from `window.location` — which is the Symfony
+                // page, not our dev server — so HMR and the `/_rspack/lazy/trigger` request hit the
+                // wrong origin (Symfony 404s them). Pin the client to the dev-server origin instead.
+                // `<port>` is a token Rsbuild substitutes with the real resolved port at server start
+                // (the port is dynamic and unknown in this config-time hook). `127.0.0.1` is a
+                // loopback host, which is "potentially trustworthy", so `ws://` is allowed even when
+                // Symfony serves the page over HTTPS (it is not mixed content). Setting the protocol
+                // explicitly stops the client inferring `wss` from an HTTPS page when the dev server
+                // itself is plain HTTP. Lazy compilation reads the same `dev.client`, so this fixes it
+                // too. (A non-loopback dev host with an HTTPS Symfony page would need the dev server on
+                // HTTPS; the loopback default needs no TLS on the dev server.)
+                config.dev ??= {};
+                config.dev.client = {
+                    ...config.dev.client,
+                    host: '127.0.0.1',
+                    port: '<port>',
+                    protocol: config.server.https ? 'wss' : 'ws',
+                };
+                // Async chunks (code-split JS/CSS, e.g. a lazy Stimulus controller's stylesheet) load
+                // through Rspack's chunk-loading runtime, which builds their URLs from
+                // `output.publicPath`. In dev that comes from `dev.assetPrefix` (default `/`), so the
+                // chunks resolve against the Symfony page origin and 404. The string form is used
+                // verbatim — `server.base` is NOT composed in — so it must carry the full publicPath;
+                // `<port>` is substituted with the real dev-server port at server start. Skip an
+                // absolute (CDN) publicPath, which the local dev server can't serve (mirrors the
+                // `server.base` fallback above). Dev-only: the production build uses `output.assetPrefix`.
+                if (!resolved.publicPath.includes('://')) {
+                    config.dev.assetPrefix = `${config.server.https ? 'https' : 'http'}://127.0.0.1:<port>${resolved.publicPath}`;
+                }
 
                 // Handle the bare virtual specifier. `resolve.alias` cannot: Rspack's resolver
                 // (enhanced-resolve) treats any request matching a URI-scheme pattern
@@ -83,7 +116,12 @@ export default function symfony(options?: Options): RsbuildPlugin {
                 const prevList = Array.isArray(prev) ? prev : prev ? [prev] : [];
                 config.tools.rspack = [
                     ...prevList,
-                    (_rspackConfig, { appendPlugins }) => {
+                    (rspackConfig, { appendPlugins }) => {
+                        rspackConfig.experiments ??= {};
+                        rspackConfig.experiments.outputModule = true;
+                        rspackConfig.output ??= {};
+                        rspackConfig.output.module = true;
+                        rspackConfig.output.chunkFormat = 'module';
                         if (vmPlugin) {
                             // Stimulus enabled: redirect to the absolute path backed by `vmPlugin` (see above).
                             appendPlugins([

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -179,7 +179,12 @@ export interface EntryFiles {
 
 export interface DevServer {
     origin: string;
-    client: 'vite' | null;
+    /**
+     * URL of the HMR client script to inject (Vite serves it under `base`, e.g.
+     * `http://127.0.0.1:5173/build/@vite/client`), or `null` when the bundler compiles its client
+     * into the entry (Rsbuild) so nothing extra needs to be rendered.
+     */
+    client: string | null;
 }
 
 export interface AssetEntry {

--- a/assets/test/core/format.test.ts
+++ b/assets/test/core/format.test.ts
@@ -19,13 +19,13 @@ const graph: NormalizedGraph = {
 };
 
 describe('buildEntrypoints', () => {
-    it('prefixes every asset list with publicPath', () => {
+    it('emits docroot-relative references (no leading slash) for a build', () => {
         const out = buildEntrypoints(graph, ctx);
         expect(out.entryPoints.app).toEqual({
-            js: ['/build/app-a1b2.js'],
-            css: ['/build/app-c3d4.css'],
-            preload: ['/build/vendor-e5f6.js'],
-            dynamic: ['/build/lazy-x.js'],
+            js: ['build/app-a1b2.js'],
+            css: ['build/app-c3d4.css'],
+            preload: ['build/vendor-e5f6.js'],
+            dynamic: ['build/lazy-x.js'],
         });
     });
 
@@ -38,22 +38,22 @@ describe('buildEntrypoints', () => {
 
     it('keeps empty arrays for entries without css/preload/dynamic', () => {
         const out = buildEntrypoints(graph, ctx);
-        expect(out.entryPoints.admin).toEqual({ js: ['/build/admin-99.js'], css: [], preload: [], dynamic: [] });
+        expect(out.entryPoints.admin).toEqual({ js: ['build/admin-99.js'], css: [], preload: [], dynamic: [] });
     });
 
-    it('inserts a slash when urlPrefix has no trailing slash', () => {
+    it('strips the leading slash even when urlPrefix has no trailing slash', () => {
         const out = buildEntrypoints(graph, { ...ctx, urlPrefix: '/build' });
-        expect(out.entryPoints.app.js).toEqual(['/build/app-a1b2.js']);
+        expect(out.entryPoints.app.js).toEqual(['build/app-a1b2.js']);
     });
 
-    it('emits a top-level integrity map keyed by URL when the graph carries hashes', () => {
+    it('emits a top-level integrity map keyed by reference when the graph carries hashes', () => {
         const out = buildEntrypoints(
             { ...graph, integrity: { 'app-a1b2.js': 'sha384-JS', 'app-c3d4.css': 'sha384-CSS' } },
             ctx
         );
         expect(out.integrity).toEqual({
-            '/build/app-a1b2.js': 'sha384-JS',
-            '/build/app-c3d4.css': 'sha384-CSS',
+            'build/app-a1b2.js': 'sha384-JS',
+            'build/app-c3d4.css': 'sha384-CSS',
         });
     });
 
@@ -64,7 +64,7 @@ describe('buildEntrypoints', () => {
     it('builds URLs from urlPrefix but emits the original publicPath field', () => {
         const devCtx: BuildContext = {
             isProd: false,
-            devServer: { origin: 'http://127.0.0.1:5173', client: 'vite' },
+            devServer: { origin: 'http://127.0.0.1:5173', client: 'http://127.0.0.1:5173/build/@vite/client' },
             publicPath: '/build/',
             urlPrefix: 'http://127.0.0.1:5173/build/',
             manifestKeyPrefix: 'build/',
@@ -74,7 +74,10 @@ describe('buildEntrypoints', () => {
             devCtx
         );
         expect(out.publicPath).toBe('/build/');
-        expect(out.devServer).toEqual({ origin: 'http://127.0.0.1:5173', client: 'vite' });
+        expect(out.devServer).toEqual({
+            origin: 'http://127.0.0.1:5173',
+            client: 'http://127.0.0.1:5173/build/@vite/client',
+        });
         expect(out.entryPoints.app.js).toEqual(['http://127.0.0.1:5173/build/assets/app.js']);
     });
 });
@@ -104,7 +107,7 @@ describe('buildManifest', () => {
         const g: NormalizedGraph = { entryPoints: {}, assets: [{ logicalName: 'app.js', fileName: 'app-a1b2.js' }] };
         const devCtx: BuildContext = {
             isProd: false,
-            devServer: { origin: 'http://127.0.0.1:5173', client: 'vite' },
+            devServer: { origin: 'http://127.0.0.1:5173', client: 'http://127.0.0.1:5173/build/@vite/client' },
             publicPath: '/build/',
             urlPrefix: 'http://127.0.0.1:5173/build/',
             manifestKeyPrefix: 'build/',

--- a/assets/test/integration/integrity.test.ts
+++ b/assets/test/integration/integrity.test.ts
@@ -15,9 +15,9 @@ const fixture = join(import.meta.dirname, '../fixtures/basic');
 function assertIntegrityMatchesDisk(out: string, integrity: Record<string, string>): void {
     expect(Object.keys(integrity).length).toBeGreaterThan(0);
     for (const [url, sri] of Object.entries(integrity)) {
-        expect(url).toMatch(/^\/build\//);
+        expect(url).toMatch(/^build\//);
         expect(sri).toMatch(/^sha384-/);
-        const diskPath = join(out, url.replace(/^\/build\//, ''));
+        const diskPath = join(out, url.replace(/^build\//, ''));
         expect(computeIntegrity(readFileSync(diskPath), ['sha384'])).toBe(sri);
     }
 }

--- a/assets/test/integration/rsbuild-build.test.ts
+++ b/assets/test/integration/rsbuild-build.test.ts
@@ -25,7 +25,7 @@ describe('rsbuild build emits Symfony files and no HTML', () => {
         expect(entry.devServer).toBeNull();
         expect(entry.publicPath).toBe('/build/');
         expect(Object.keys(entry.entryPoints).sort()).toEqual(['admin', 'app']);
-        expect(entry.entryPoints.app.js.some((u: string) => /^\/build\/.*\.js$/.test(u))).toBe(true);
+        expect(entry.entryPoints.app.js.some((u: string) => /^build\/.*\.js$/.test(u))).toBe(true);
 
         const manifest = JSON.parse(readFileSync(join(out, 'manifest.json'), 'utf8'));
         expect(Object.keys(manifest).length).toBeGreaterThan(0);
@@ -60,5 +60,24 @@ describe('rsbuild build emits Symfony files and no HTML', () => {
 
         const entry = JSON.parse(readFileSync(join(outputPath, 'entrypoints.json'), 'utf8'));
         expect(Object.keys(entry.entryPoints)).toEqual(['app']);
+    }, 60_000);
+
+    it('emits ES-module output (loadable under <script type="module">)', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-rsbuild-esm-'));
+        const rsbuild = await createRsbuild({
+            cwd: fixture,
+            rsbuildConfig: {
+                mode: 'production',
+                source: { entry: { app: join(fixture, 'app.js') } },
+                plugins: [Symfony({ outputPath: out, publicPath: '/build/' })],
+            },
+        });
+        await rsbuild.build();
+
+        // The entry JS chunk is an ES module: ESM output uses `export`/`import` at top level.
+        const entry = JSON.parse(readFileSync(join(out, 'entrypoints.json'), 'utf8'));
+        const appJs = (entry.entryPoints.app.js as string[]).find((u) => u.endsWith('.js'))!;
+        const contents = readFileSync(join(out, appJs.replace(/^build\//, '')), 'utf8');
+        expect(/\b(export|import)\b/.test(contents)).toBe(true);
     }, 60_000);
 });

--- a/assets/test/integration/rsbuild-dev.test.ts
+++ b/assets/test/integration/rsbuild-dev.test.ts
@@ -96,3 +96,33 @@ describe('rsbuild dev writes absolute dev-server URLs and no HTML', () => {
         expect(htmlFiles).toEqual([]);
     }, 60_000);
 });
+
+describe('rsbuild dev pins the HMR client to the loopback dev-server origin', () => {
+    it('sets dev.client host/port/protocol so HMR and lazy compilation target the dev server', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-rsbuild-devclient-'));
+        const rsbuild = await createRsbuild({
+            cwd: fixture,
+            rsbuildConfig: {
+                mode: 'development',
+                source: { entry: { app: join(fixture, 'app.js') } },
+                plugins: [Symfony({ outputPath: out, publicPath: '/build/' })],
+            },
+        });
+
+        const { origin } = await rsbuild.inspectConfig();
+
+        // Without this, the compiled HMR client derives its socket URL from window.location (the
+        // Symfony page) and 404s. `<port>` is substituted with the real port at server start; the
+        // 127.0.0.1 loopback host keeps `ws://` allowed from an HTTPS Symfony page; `ws` matches the
+        // plain-HTTP dev server. Lazy compilation reads the same config.
+        expect(origin.rsbuildConfig.dev?.client).toMatchObject({
+            host: '127.0.0.1',
+            port: '<port>',
+            protocol: 'ws',
+        });
+
+        // Async chunks build their URLs from the dev runtime publicPath; it must point at the dev
+        // server + publicPath (verbatim, `<port>` resolved at start), not the page origin.
+        expect(origin.rsbuildConfig.dev?.assetPrefix).toBe('http://127.0.0.1:<port>/build/');
+    });
+});

--- a/assets/test/integration/vite-build.test.ts
+++ b/assets/test/integration/vite-build.test.ts
@@ -33,9 +33,9 @@ describe('vite build emits Symfony files', () => {
         expect(entry.publicPath).toBe('/build/');
         expect(Object.keys(entry.entryPoints).sort()).toEqual(['admin', 'app']);
         expect(entry.entryPoints.app.js).toHaveLength(1);
-        expect(entry.entryPoints.app.js[0]).toMatch(/^\/build\/app-.*\.js$/);
-        expect(entry.entryPoints.app.css[0]).toMatch(/^\/build\/.*\.css$/);
-        expect(entry.entryPoints.app.dynamic[0]).toMatch(/^\/build\/.*\.js$/);
+        expect(entry.entryPoints.app.js[0]).toMatch(/^build\/app-.*\.js$/);
+        expect(entry.entryPoints.app.css[0]).toMatch(/^build\/.*\.css$/);
+        expect(entry.entryPoints.app.dynamic[0]).toMatch(/^build\/.*\.js$/);
     }, 30_000);
 
     it('writes a flat manifest.json with logical keys and public URLs', async () => {

--- a/assets/test/integration/vite-dev.test.ts
+++ b/assets/test/integration/vite-dev.test.ts
@@ -32,10 +32,11 @@ describe('vite serve writes a dev entrypoints.json', () => {
 
         expect(entry.isProd).toBe(false);
         expect(entry.publicPath).toBe('/build/');
-        expect(entry.devServer.client).toBe('vite');
-        expect(entry.devServer.origin).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
-
         const origin = entry.devServer.origin;
+        expect(origin).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+        // The HMR client is served under `base` (our publicPath), so its URL carries `/build/`.
+        expect(entry.devServer.client).toBe(`${origin}/build/@vite/client`);
+
         expect(Object.keys(entry.entryPoints).sort()).toEqual(['admin', 'app']);
         expect(entry.entryPoints.app.js).toEqual([`${origin}/build/app.js`]);
         expect(entry.entryPoints.app.css).toEqual([]);

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,16 @@
         }
     ],
     "require": {
-        "php": ">=8.4"
+        "php": ">=8.4",
+        "symfony/asset": "^7.4|^8.0",
+        "twig/twig": "^3.0"
     },
     "require-dev": {
         "symfony/framework-bundle": "^7.4|^8.0",
         "phpunit/phpunit": "^13.2",
         "phpstan/phpstan": "^2.2",
-        "friendsofphp/php-cs-fixer": "^3.95"
+        "friendsofphp/php-cs-fixer": "^3.95",
+        "symfony/web-link": "^7.4|^8.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Reprise\\": "src/" }

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,31 +4,28 @@ Symfony Reprise
 **EXPERIMENTAL** This bundle is experimental and is likely to change,
 or even change drastically.
 
-Webpack Encore gave Symfony first-class asset integration for Webpack.
-Symfony Reprise brings the same to `Vite`_ and `Rsbuild`_.
+Webpack Encore gave Symfony first-class asset integration for Webpack. Symfony Reprise brings the same to `Vite`_
+and `Rsbuild`_.
 
-Vite and Rsbuild already handle **Sass/Less/PostCSS**, **TypeScript**,
-**JSX/Vue/Svelte**, **code splitting**, **content hashing**, **source maps**,
-**minification** and **HMR** on their own, so Symfony Reprise does not
-reimplement any of that. It covers only the Symfony-side glue the bundlers
-leave out:
+Vite and Rsbuild already handle **Sass/Less/PostCSS**, **TypeScript**, **JSX/Vue/Svelte**, **code splitting**,
+**content hashing**, **source maps**, **minification** and **HMR** on their own, so Symfony Reprise does not
+reimplement any of that. It covers only the Symfony-side glue the bundlers leave out:
 
-- **Multiple entries**: build several independent entry points from one
-  config
+- **Multiple entries**: build several independent entry points from one config
 - ``entrypoints.json``: generated in both build and dev-server modes
 - ``manifest.json``: maps each logical filename to its hashed URL
 - **Asset versioning**: content-hash cache busting, wired into the manifest
 - **File copy**: copy static files into the build, keyed in the manifest
 - **Dev server and HMR**: points Twig at the running Vite/Rsbuild server
-- **Symfony UX / Stimulus**: registers ``controllers.json`` and local
-  controllers, eager or lazy
+- **Twig tag rendering**: ``reprise_entry_script_tags``/``reprise_entry_link_tags`` render straight from
+  ``entrypoints.json``
+- **Symfony UX / Stimulus**: registers ``controllers.json`` and local controllers, eager or lazy
 - **CDN support**: serve built assets from an absolute ``publicPath``
 - **Subresource Integrity**: SRI hashes in ``entrypoints.json``
 
-It generates the Encore-compatible ``entrypoints.json`` and ``manifest.json``
-that Reprise's own Symfony bundle (``RepriseBundle``, still a stub) reads to
-render the ``<script>`` and ``<link>`` tags, wires up the native dev server,
-and turns your Stimulus controllers into a running application.
+It generates the Encore-compatible ``entrypoints.json`` and ``manifest.json`` that ``RepriseBundle`` reads to render
+the ``<script>`` and ``<link>`` tags, wires up the native dev server, and turns your Stimulus controllers into a
+running application.
 
 Installation
 ------------
@@ -56,7 +53,9 @@ Vite
 
     export default defineConfig({
       plugins: [
-        Symfony({ /* options */ }),
+        Symfony({
+          // options
+        }),
       ],
     })
 
@@ -70,19 +69,139 @@ Rsbuild
     import Symfony from '@symfony/reprise/rsbuild'
 
     export default defineConfig({
-      plugins: [Symfony({ /* options */ })],
+      plugins: [
+        Symfony({
+          // options
+        }),
+      ],
     })
+
+Rendering asset tags
+--------------------
+
+This is where Reprise pays off: once ``entrypoints.json`` exists, ``RepriseBundle`` reads it and renders the
+``<script>`` and ``<link>`` tags for an entry directly in Twig, the same experience `WebpackEncoreBundle`_ gives you
+with ``encore_entry_script_tags`` and ``encore_entry_link_tags``.
+
+Four Twig functions come with it:
+
+.. code-block:: twig
+
+    {# templates/base.html.twig #}
+    <!DOCTYPE html>
+    <html>
+        <head>
+            <meta charset="UTF-8">
+            <title>{% block title %}Welcome!{% endblock %}</title>
+            <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text><text y=%221.3em%22 x=%220.2em%22 font-size=%2276%22 fill=%22%23fff%22>sf</text></svg>">
+            {% block stylesheets %}
+                {{ reprise_entry_link_tags('app') }}
+            {% endblock %}
+
+            {% block javascripts %}
+                {# reprise_entry_script_tags renders <script type="module"> (ESM output from both Vite and Rsbuild) #}
+                {{ reprise_entry_script_tags('app') }}
+            {% endblock %}
+        </head>
+        <body>
+            {% block body %}{% endblock %}
+        </body>
+    </html>
+
+``reprise_entry_js_files('app')`` and ``reprise_entry_css_files('app')`` are the same lookup, minus the HTML: they
+return the raw URL lists, for the rare case where you need the paths rather than the tags.
+
+If you're migrating from Webpack Encore, it's a tag-for-tag swap (Reprise is Encore's heritage, so the template
+shape hasn't changed):
+
+.. list-table::
+   :header-rows: 1
+
+   * - Webpack Encore
+     - Symfony Reprise
+     - Output
+   * - ``encore_entry_link_tags('app')``
+     - ``reprise_entry_link_tags('app')``
+     - ``<link rel="stylesheet">`` tags
+   * - ``encore_entry_script_tags('app')``
+     - ``reprise_entry_script_tags('app')``
+     - ``<script type="module">`` tags
+   * - ``encore_entry_css_files('app')``
+     - ``reprise_entry_css_files('app')``
+     - CSS URL list
+   * - ``encore_entry_js_files('app')``
+     - ``reprise_entry_js_files('app')``
+     - JS URL list
+
+**Nothing to set up for the common case.** The tags resolve against Symfony's default asset package, so a standard
+project needs nothing beyond installing the bundle (see `Configuration`_ below for the options). The snippet is the
+same whether Vite or Rsbuild produced ``entrypoints.json``, and there's nothing to configure for dev either: in dev
+``reprise_entry_script_tags`` injects the Vite HMR client automatically, while under Rsbuild the client is compiled
+into the bundle.
+
+Configuration
+-------------
+
+Reprise exposes a few optional settings under its own configuration, all shown here at their default value:
+
+.. code-block:: yaml
+
+    # config/packages/reprise.yaml
+    reprise:
+        # Directory the @symfony/reprise plugin writes entrypoints.json and manifest.json into.
+        output_path: '%kernel.project_dir%/public/build'
+
+        # Throw when entrypoints.json or a requested entry is missing, instead of rendering nothing.
+        strict_mode: true
+
+        # A framework.assets package name used to resolve entry URLs. null uses the default package.
+        asset_package: null
+
+        # crossorigin attribute set alongside SRI integrity: false, 'anonymous' or 'use-credentials'.
+        crossorigin: false
+
+        # Register rendered assets as WebLink HTTP/2 Link: preload headers (needs symfony/web-link).
+        preload: true
+
+        # Default attributes added to every rendered <script> / <link> tag.
+        script_attributes: []
+        link_attributes: []
+
+- ``output_path``: filesystem directory holding ``entrypoints.json`` and ``manifest.json``. Must match the plugin's
+  own ``outputPath``.
+- ``strict_mode``: when ``true`` (the default), throws a clear exception on a missing file or an unknown entry; when
+  ``false``, renders nothing instead.
+- ``asset_package``: resolve entry URLs through a specific ``framework.assets`` package instead of the default one.
+  You only need this if your default package applies a version strategy, which would re-hash files Reprise already
+  content-hashed and break the URLs. Point it at a package with ``version: false`` (see below).
+- ``crossorigin``: ``false``, ``'anonymous'`` or ``'use-credentials'`` (any other value is a configuration error),
+  applied together with SRI integrity (see `Subresource Integrity`_).
+- ``preload``: emit WebLink HTTP/2 ``Link:`` preload headers when `symfony/web-link`_ is installed; ``false`` to
+  disable.
+- ``script_attributes`` / ``link_attributes``: maps of default attributes added to every generated tag, e.g.
+  ``defer: true`` or ``data-turbo-track: reload``.
+
+If you set ``asset_package``, define that package with ``version: false``:
+
+.. code-block:: yaml
+
+    reprise:
+        asset_package: reprise
+
+    framework:
+        assets:
+            packages:
+                reprise:
+                    version: false
 
 Symfony UX / Stimulus controllers
 ---------------------------------
 
-This is the Vite/Rsbuild counterpart of what `@symfony/stimulus-bridge`_ did
-for Webpack Encore: it turns your ``controllers.json`` into a Stimulus
-application, with the same enable step, same helper, same local-controllers
+This is the Vite/Rsbuild counterpart of what `@symfony/stimulus-bridge`_ did for Webpack Encore: it turns your
+``controllers.json`` into a Stimulus application, with the same enable step, same helper, same local-controllers
 convention.
 
-Enable it by pointing the plugin at your ``controllers.json`` (this is what
-turns the feature on):
+Enable it by pointing the plugin at your ``controllers.json`` (this is what turns the feature on):
 
 .. code-block:: javascript
 
@@ -105,12 +224,10 @@ Then start the app from your entry:
 
     const app = startStimulusApp()
 
-**Local controllers.** Any ``assets/controllers/*_controller.{js,ts}`` is
-registered automatically. The filename becomes the identifier
-(``hello_controller.js`` becomes ``hello``, ``admin/user_controller.js``
-becomes ``admin--user``). To load a controller on demand, put a
-``stimulusFetch: 'lazy'`` comment directly above the class (after the
-imports) — a block or a single-line comment both work:
+**Local controllers.** Any ``assets/controllers/*_controller.{js,ts}`` is registered automatically. The filename
+becomes the identifier (``hello_controller.js`` becomes ``hello``, ``admin/user_controller.js`` becomes
+``admin--user``). To load a controller on demand, put a ``stimulusFetch: 'lazy'`` comment directly above the
+class; a block or a single-line comment both work.
 
 .. code-block:: javascript
 
@@ -119,21 +236,19 @@ imports) — a block or a single-line comment both work:
     /* stimulusFetch: 'lazy' */
     export default class extends Controller {}
 
-(``// stimulusFetch: 'lazy'`` on the line above the class works too, as does a
-preserved ``/*! stimulusFetch: 'lazy' */`` comment — the form tsc and esbuild keep
-through minification.)
+(``// stimulusFetch: 'lazy'`` on the line above the class works too, as does a preserved
+``/*! stimulusFetch: 'lazy' */`` comment: the form tsc and esbuild keep through minification.)
 
-**Third-party UX packages.** Controllers declared in ``controllers.json`` are
-resolved from ``node_modules``, so install them with your package manager, the
-same as you would with Webpack Encore:
+**Third-party UX packages.** Controllers declared in ``controllers.json`` are resolved from ``node_modules``, so
+install them with your package manager, the same as you would with Webpack Encore. For example, with Stimulus and
+UX Leaflet Map:
 
 .. code-block:: terminal
 
-    $ npm install @hotwired/stimulus @symfony/ux-turbo @symfony/ux-leaflet-map
+    $ npm install @hotwired/stimulus @symfony/ux-leaflet-map
 
-Some packages need a bit of bundler-specific setup on top, the same way they
-did under Webpack Encore. UX Leaflet Map, for instance, ships a CSS file meant
-for Webpack's loader and needs an alias to the plain CSS build:
+Some packages need a bit of bundler-specific setup on top, the same way they did under Webpack Encore. UX Leaflet
+Map, for instance, ships a CSS file meant for Webpack's loader and needs an alias to the plain CSS build:
 
 .. code-block:: javascript
 
@@ -151,11 +266,10 @@ Check each package's own docs for this kind of tweak.
 File copy
 ---------
 
-Some assets are referenced by a stable path straight from your templates,
-like ``{{ asset('build/images/logo.svg') }}``, rather than imported from
-JavaScript or CSS. Point ``copy`` at the directories that hold them and
-Reprise copies each file into the build and records it in ``manifest.json``,
-so the ``asset()`` helper resolves it to the hashed URL:
+Some assets are referenced by a stable path straight from your templates, like
+``{{ asset('build/images/logo.svg') }}``, rather than imported from JavaScript or CSS. Point ``copy`` at the
+directories that hold them and Reprise copies each file into the build and records it in ``manifest.json``, so the
+``asset()`` helper resolves it to the hashed URL:
 
 .. code-block:: javascript
 
@@ -166,7 +280,12 @@ so the ``asset()`` helper resolves it to the hashed URL:
     export default defineConfig({
       plugins: [
         Symfony({
-          copy: [{ from: 'assets/images', to: 'images' }],
+          copy: [
+            {
+              from: 'assets/images',
+              to: 'images',
+            },
+          ],
         }),
       ],
     })
@@ -180,31 +299,35 @@ so the ``asset()`` helper resolves it to the hashed URL:
     export default defineConfig({
       plugins: [
         Symfony({
-          copy: [{ from: 'assets/images', to: 'images' }],
+          copy: [
+            {
+              from: 'assets/images',
+              to: 'images',
+            },
+          ],
         }),
       ],
     })
 
-``from`` and ``to`` are both required: ``from`` is the source directory (relative
-to your project root), ``to`` is the destination prefix used for the manifest key.
-Restrict which files are copied with ``pattern``, a regular expression tested
-against each file's path relative to ``from`` (by default every file is copied).
-``includeSubdirectories`` defaults to ``true``; set it to ``false`` to turn off
-recursion.
+``from`` and ``to`` are both required: ``from`` is the source directory (relative to your project root), ``to`` is
+the destination prefix used for the manifest key. Restrict which files are copied with ``pattern``, a regular
+expression tested against each file's path relative to ``from`` (by default every file is copied).
+``includeSubdirectories`` defaults to ``true``; set it to ``false`` to turn off recursion.
 
-In build mode, copied files get a content hash in their filename for cache
-busting. In dev mode, they're copied verbatim, no hash. Either way, they land in
-``public/build`` and are served by the Symfony web server, not by the Vite/Rsbuild
-dev server, so they're available whether or not the dev server is running.
+How copied files are handled depends on the mode:
+
+- **Build**: each file gets a content hash in its filename for cache busting.
+- **Dev**: files are copied verbatim, no hash.
+
+Either way they land in ``public/build`` and are served by the Symfony web server, not the Vite/Rsbuild dev server,
+so they're available whether or not the dev server is running.
 
 Using a CDN
 -----------
 
-To serve your built assets from a CDN, set ``publicPath`` to the absolute CDN
-URL, for the production build only. In dev, the dev server serves assets
-directly, so keep the local ``/build/`` path there. Both bundlers expose the
-mode through the function form of their config, so switch on
-``command === 'build'``:
+To serve your built assets from a CDN, set ``publicPath`` to the absolute CDN URL, for the production build only. In
+dev, the dev server serves assets directly, so keep the local ``/build/`` path there. Both bundlers expose the mode
+through the function form of their config, so switch on ``command === 'build'``:
 
 .. code-block:: javascript
 
@@ -242,9 +365,8 @@ mode through the function form of their config, so switch on
       ],
     }))
 
-With an absolute ``publicPath``, ``manifestKeyPrefix`` is **required**: Reprise
-has no way to guess the right prefix for the ``manifest.json`` keys, and
-throws a clear error if it's missing. Keys stay logical, values point at the
+With an absolute ``publicPath``, ``manifestKeyPrefix`` is **required**: Reprise has no way to guess the right prefix
+for the ``manifest.json`` keys, and throws a clear error if it's missing. Keys stay logical, values point at the
 CDN:
 
 .. code-block:: json
@@ -253,23 +375,20 @@ CDN:
       "build/app.js": "https://my-cool-app.com.global.prod.fastly.net/build/app-1a2b3c.js"
     }
 
-``entrypoints.json`` is rewritten the same way, so the ``<script>`` and
-``<link>`` tags render with CDN URLs. You still have to upload the built files
-to the CDN yourself, or set up origin pull. For a CDN subdirectory, include it
+``entrypoints.json`` is rewritten the same way, so the ``<script>`` and ``<link>`` tags render with CDN URLs. You
+still have to upload the built files to the CDN yourself, or set up origin pull. For a CDN subdirectory, include it
 in the URL (``https://my-cool-app.com.global.prod.fastly.net/awesome-website/build/``).
 
 Subresource Integrity
 ---------------------
 
-When enabled, Reprise adds an ``integrity`` map to ``entrypoints.json`` (asset
-URL -> SRI hash). Reprise's Symfony bundle reads that map and renders
-``integrity="..."`` on the generated ``<script>`` and ``<link>`` tags, so the
-browser refuses any asset whose bytes were tampered with.
+When enabled, Reprise adds an ``integrity`` map to ``entrypoints.json`` (asset URL -> SRI hash). ``RepriseBundle``
+reads that map and renders ``integrity="..."`` on the generated ``<script>`` and ``<link>`` tags, so the browser
+refuses any asset whose bytes were tampered with.
 
-The ``integrity`` option takes an object ``{ enabled, algorithms? }``. It only
-makes sense for the production build: the dev server serves changing
-in-memory assets, so no hashes are emitted in dev. As with the CDN example,
-toggle it with ``command === 'build'``:
+The ``integrity`` option takes an object ``{ enabled, algorithms? }``. It only makes sense for the production build:
+the dev server serves changing in-memory assets, so no hashes are emitted in dev. As with the CDN example, toggle it
+with ``command === 'build'``:
 
 .. code-block:: javascript
 
@@ -280,7 +399,10 @@ toggle it with ``command === 'build'``:
     export default defineConfig(({ command }) => ({
       plugins: [
         Symfony({
-          integrity: { enabled: command === 'build', algorithms: ['sha384'] },
+          integrity: {
+            enabled: command === 'build',
+            algorithms: ['sha384'],
+          },
         }),
       ],
     }))
@@ -294,15 +416,17 @@ toggle it with ``command === 'build'``:
     export default defineConfig(({ command }) => ({
       plugins: [
         Symfony({
-          integrity: { enabled: command === 'build', algorithms: ['sha384'] },
+          integrity: {
+            enabled: command === 'build',
+            algorithms: ['sha384'],
+          },
         }),
       ],
     }))
 
-``algorithms`` is optional and defaults to ``['sha384']``. Accepted values are
-``'sha256'``, ``'sha384'`` and ``'sha512'``. Passing several (e.g.
-``['sha256', 'sha512']``) writes multiple space-separated hashes per file,
-which the browser treats as "any one of these must match".
+``algorithms`` is optional and defaults to ``['sha384']``. Accepted values are ``'sha256'``, ``'sha384'`` and
+``'sha512'``. Passing several (e.g. ``['sha256', 'sha512']``) writes multiple space-separated hashes per file, which
+the browser treats as "any one of these must match".
 
 The resulting ``entrypoints.json`` gets an extra ``integrity`` section:
 
@@ -315,10 +439,11 @@ The resulting ``entrypoints.json`` gets an extra ``integrity`` section:
       }
     }
 
-Hashes cover every referenced file in each entry (js, css, and
-preloaded/dynamic chunks), and since they're computed from the files actually
-written to disk, they stay correct through minification and hashing.
+Hashes cover every referenced file in each entry (js, css, and preloaded/dynamic chunks), and since they're computed
+from the files actually written to disk, they stay correct through minification and hashing.
 
 .. _Vite: https://vite.dev/
 .. _Rsbuild: https://rsbuild.dev/
 .. _`@symfony/stimulus-bridge`: https://github.com/symfony/stimulus-bridge
+.. _WebpackEncoreBundle: https://github.com/symfony/webpack-encore-bundle
+.. _`symfony/web-link`: https://symfony.com/doc/current/web_link.html

--- a/docs/superpowers/plans/2026-07-11-twig-asset-tags-phase1-js.md
+++ b/docs/superpowers/plans/2026-07-11-twig-asset-tags-phase1-js.md
@@ -1,0 +1,263 @@
+# Twig Asset Tags — Phase 1 (JS: ADR 0001 entrypoints format + ESM) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the JS plugin emit `entrypoints.json` in the ADR-0001 shape the PHP tag renderer (Phase 2) consumes: build references are docroot-relative (no leading slash), the SRI map is keyed by those references, and both bundlers emit ES modules so the renderer can always use `type="module"`.
+
+**Architecture:** A one-line format tweak in `assets/src/core/format.ts` (`buildEntrypoints` only; `buildManifest` untouched) turns build references from `/build/app-<hash>.js` into `build/app-<hash>.js` and keys the integrity map the same way. Dev references stay absolute (nothing to strip). Separately, the Rsbuild adapter is switched to ES-module output so the entry chunks load under `<script type="module">` like Vite's.
+
+**Tech Stack:** TypeScript (ESM, strict, ES2017, `node:` prefix), Vitest, tsdown; Vite + Rollup; Rsbuild + Rspack.
+
+## Global Constraints
+
+- ESM only, strict TypeScript, ES2017 target, `node:` prefix for Node builtins.
+- Bundler symmetry: a functional/integration test for one bundler ships with the other, including negative/off cases.
+- Only `entrypoints.json` changes in Phase 1. `manifest.json` (`buildManifest`) is a separate concern and MUST NOT change.
+- Build references: docroot-relative, no leading slash (`build/app-<hash>.js`). Dev references: absolute dev-server-origin URLs, unchanged.
+- SRI integrity map keyed by the reference (relative in build), not the final URL.
+- Commit scope `[Entrypoints]` for the format/SRI change, `[Rsbuild]` for the ESM-output change.
+- Note (context, not a task): Symfony `PathPackage`/`UrlPackage` `ltrim($path, '/')`, so `/build/app.js` and `build/app.js` resolve identically. The strip is for ADR fidelity and a clean reference contract, not because Packages needs it.
+
+---
+
+## Task 1: Emit docroot-relative build references + re-key SRI
+
+**Files:**
+- Modify: `assets/src/core/format.ts`
+- Test: `assets/test/core/format.test.ts`
+- Test (assertions updated): `assets/test/integration/vite-build.test.ts`, `assets/test/integration/rsbuild-build.test.ts`, `assets/test/integration/integrity.test.ts`
+
+**Interfaces:**
+- Produces: `buildEntrypoints(graph, ctx)` now emits each `js`/`css`/`preload`/`dynamic` reference and each `integrity` key with the leading slash stripped (build: `build/app-<hash>.js`; dev absolute URLs unchanged). `buildManifest` unchanged.
+
+- [ ] **Step 1: Update the `buildEntrypoints` unit expectations to the relative shape (RED)**
+
+In `assets/test/core/format.test.ts`, change the build-mode expectations to have no leading slash, and rename the two affected tests. Replace lines 22-30 (the `prefixes every asset list with publicPath` test):
+
+```ts
+    it('emits docroot-relative references (no leading slash) for a build', () => {
+        const out = buildEntrypoints(graph, ctx);
+        expect(out.entryPoints.app).toEqual({
+            js: ['build/app-a1b2.js'],
+            css: ['build/app-c3d4.css'],
+            preload: ['build/vendor-e5f6.js'],
+            dynamic: ['build/lazy-x.js'],
+        });
+    });
+```
+
+In the `keeps empty arrays…` test, replace its assertion (line 41) with the relative shape:
+
+```ts
+        expect(out.entryPoints.admin).toEqual({ js: ['build/admin-99.js'], css: [], preload: [], dynamic: [] });
+```
+
+Replace the `inserts a slash…` test body (lines 44-47):
+
+```ts
+    it('strips the leading slash even when urlPrefix has no trailing slash', () => {
+        const out = buildEntrypoints(graph, { ...ctx, urlPrefix: '/build' });
+        expect(out.entryPoints.app.js).toEqual(['build/app-a1b2.js']);
+    });
+```
+
+Replace the integrity test (lines 49-58) to be keyed by reference:
+
+```ts
+    it('emits a top-level integrity map keyed by reference when the graph carries hashes', () => {
+        const out = buildEntrypoints(
+            { ...graph, integrity: { 'app-a1b2.js': 'sha384-JS', 'app-c3d4.css': 'sha384-CSS' } },
+            ctx
+        );
+        expect(out.integrity).toEqual({
+            'build/app-a1b2.js': 'sha384-JS',
+            'build/app-c3d4.css': 'sha384-CSS',
+        });
+    });
+```
+
+Leave the dev test (lines 64-79) unchanged: its reference `http://127.0.0.1:5173/build/assets/app.js` has no leading slash to strip. Leave the entire `buildManifest` describe (lines 82-113) unchanged.
+
+- [ ] **Step 2: Run the unit tests to verify they fail**
+
+Run: `pnpm vitest run assets/test/core/format.test.ts`
+Expected: FAIL — current `buildEntrypoints` emits `/build/app-a1b2.js` (leading slash), tests now expect `build/app-a1b2.js`.
+
+- [ ] **Step 3: Implement the relative reference in `assets/src/core/format.ts`**
+
+Add a helper and use it in `buildEntrypoints` only (leave `joinUrl` and `buildManifest` as-is):
+
+```ts
+function toReference(prefix: string, name: string): string {
+    // Docroot-relative reference (ADR 0001): a build URL like `/build/app-<hash>.js` becomes
+    // `build/app-<hash>.js`; an absolute dev-server URL has no leading slash and is unchanged.
+    return joinUrl(prefix, name).replace(/^\//, '');
+}
+```
+
+In `buildEntrypoints`, replace the four `joinUrl(ctx.urlPrefix, f)` mappings and the integrity `joinUrl(ctx.urlPrefix, fileName)` key with `toReference`:
+
+```ts
+        entryPoints[name] = {
+            js: files.js.map((f) => toReference(ctx.urlPrefix, f)),
+            css: files.css.map((f) => toReference(ctx.urlPrefix, f)),
+            preload: files.preload.map((f) => toReference(ctx.urlPrefix, f)),
+            dynamic: files.dynamic.map((f) => toReference(ctx.urlPrefix, f)),
+        };
+```
+
+and:
+
+```ts
+        out.integrity = Object.fromEntries(
+            Object.entries(graph.integrity).map(([fileName, sri]) => [toReference(ctx.urlPrefix, fileName), sri])
+        );
+```
+
+- [ ] **Step 4: Run the unit tests to verify they pass**
+
+Run: `pnpm vitest run assets/test/core/format.test.ts`
+Expected: PASS (buildEntrypoints relative; buildManifest unchanged).
+
+- [ ] **Step 5: Update the integration test assertions (they assert leading slashes)**
+
+In `assets/test/integration/vite-build.test.ts`, lines 36-38, drop the leading slash:
+
+```ts
+        expect(entry.entryPoints.app.js[0]).toMatch(/^build\/app-.*\.js$/);
+        expect(entry.entryPoints.app.css[0]).toMatch(/^build\/.*\.css$/);
+        expect(entry.entryPoints.app.dynamic[0]).toMatch(/^build\/.*\.js$/);
+```
+
+(Leave the manifest assertions on lines 45-48 unchanged — the manifest still carries `/build/…` values.)
+
+In `assets/test/integration/rsbuild-build.test.ts`, line 28:
+
+```ts
+        expect(entry.entryPoints.app.js.some((u: string) => /^build\/.*\.js$/.test(u))).toBe(true);
+```
+
+In `assets/test/integration/integrity.test.ts`, line 18 (integrity keys are references now):
+
+```ts
+        expect(url).toMatch(/^build\//);
+```
+
+- [ ] **Step 6: Run the full suite (CDN test must still pass unchanged)**
+
+Run: `pnpm test`
+Expected: PASS. Note the CDN test (`assets/test/integration/cdn.test.ts`) is unaffected: an absolute `publicPath` produces absolute references (`https://cdn…/app.js`) with no leading slash to strip, so they stay absolute and the assertions hold.
+
+- [ ] **Step 7: Format, lint, commit**
+
+Run: `pnpm exec oxfmt assets/src/core/format.ts assets/test/core/format.test.ts assets/test/integration/vite-build.test.ts assets/test/integration/rsbuild-build.test.ts assets/test/integration/integrity.test.ts` then `pnpm fmt:check` and `pnpm exec oxlint assets/src assets/test`.
+
+```bash
+git add assets/src/core/format.ts assets/test/core/format.test.ts assets/test/integration/vite-build.test.ts assets/test/integration/rsbuild-build.test.ts assets/test/integration/integrity.test.ts
+git commit -m "[Entrypoints] Emit docroot-relative build references and key SRI by reference"
+```
+
+---
+
+## Task 2: Standardise Rsbuild on ES-module output
+
+**Files:**
+- Modify: `assets/src/rsbuild.ts`
+- Test: `assets/test/integration/rsbuild-build.test.ts`
+
+**Interfaces:**
+- Consumes: the Rsbuild adapter's existing `api.modifyRsbuildConfig` / `tools.rspack` wiring.
+- Produces: Rsbuild build output is ES modules (entry chunks load under `<script type="module">`), matching Vite.
+
+**Risk gate:** Rspack ES-module output for a *web* target (not a library) may not be reliable. This task is de-risk-first. Vite already emits ESM, so it needs no change.
+
+- [ ] **Step 1: Spike — determine the working Rspack ESM config**
+
+Before writing the test, verify feasibility. In `assets/src/rsbuild.ts`, inside the existing `api.modifyRsbuildConfig((config) => { … })`, try enabling module output (best current guess — adjust to what actually works):
+
+```ts
+                config.output ??= {};
+                // Standardise on ESM so the tags render as <script type="module"> like Vite.
+                (config.output as Record<string, unknown>).module = true;
+```
+
+and, in the existing `config.tools.rspack` array callback, enable the experiment on the raw Rspack config:
+
+```ts
+                    (rspackConfig) => {
+                        rspackConfig.experiments ??= {};
+                        rspackConfig.experiments.outputModule = true;
+                        rspackConfig.output ??= {};
+                        rspackConfig.output.module = true;
+                        rspackConfig.output.chunkFormat = 'module';
+                    },
+```
+
+Then run the playground Rsbuild build and inspect the entry chunk:
+
+Run: `cd playground && npm run rsbuild:build 2>&1 | tail -20` then check an entry chunk in `public/build/static/js/` uses ESM syntax (`export`/`import`) or is a module chunk.
+
+**Decision point:**
+- If the build succeeds and the entry chunk is an ES module -> proceed to Step 2 with the config that worked (fold the two snippets into the existing hooks; do not add a second `tools.rspack` callback if one already exists — extend it).
+- If the build fails or cannot produce loadable ESM web output -> **STOP and escalate**: report `BLOCKED` with the exact error. The `type="module"` decision (spec §A "ESM standardisation") must be revisited (fall back to per-bundler handling) before Phase 2. Do not force a broken config.
+
+- [ ] **Step 2: Write the failing test asserting ESM output**
+
+Add to `assets/test/integration/rsbuild-build.test.ts` (a new `it`, using the same `basic` fixture and build setup as the first test in the file — read that test for the exact `createRsbuild`/`build()` shape, then assert the emitted entry chunk is an ES module):
+
+```ts
+    it('emits ES-module output (loadable under <script type="module">)', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-rsbuild-esm-'));
+        const rsbuild = await createRsbuild({
+            cwd: fixture,
+            rsbuildConfig: {
+                mode: 'production',
+                source: { entry: { app: join(fixture, 'app.js') } },
+                plugins: [SymfonyRsbuild({ outputPath: out, publicPath: '/build/' })],
+            },
+        });
+        await rsbuild.build();
+
+        // The entry JS chunk is an ES module: ESM output uses `export`/`import` at top level.
+        const entry = JSON.parse(readFileSync(join(out, 'entrypoints.json'), 'utf8'));
+        const appJs = (entry.entryPoints.app.js as string[]).find((u) => /\.js$/.test(u))!;
+        const contents = readFileSync(join(out, appJs), 'utf8');
+        expect(/\b(export|import)\b/.test(contents)).toBe(true);
+    }, 60_000);
+```
+
+Note: `appJs` is a docroot-relative reference (`build/…`, Task 1). The file on disk is at `join(out, appJs)` since `out` is the `build` output dir and `appJs` starts with `build/`... confirm the path: the reference is `build/static/js/app.<hash>.js` and `out` already IS the build dir, so read from `join(out, appJs.replace(/^build\//, ''))`. Use:
+
+```ts
+        const contents = readFileSync(join(out, appJs.replace(/^build\//, '')), 'utf8');
+```
+
+- [ ] **Step 3: Run the test to verify it fails (before the ESM config), then passes (after)**
+
+Run: `pnpm vitest run assets/test/integration/rsbuild-build.test.ts -t "ES-module"`
+Expected: with the Step 1 config applied, PASS. If you reached Step 2, the config is in place, so this asserts it holds. (If you want a clean RED first, stash the Step 1 config, run -> FAIL "no export/import", unstash.)
+
+- [ ] **Step 4: Run the full suite + playground**
+
+Run: `pnpm test` (all green — the ESM switch must not break existing Rsbuild build/dev tests) then `cd playground && npm run rsbuild:build && npm run rsbuild:dev`-smoke (build succeeds; dev serves).
+Expected: PASS; playground Rsbuild build/dev still work.
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+git add assets/src/rsbuild.ts assets/test/integration/rsbuild-build.test.ts
+git commit -m "[Rsbuild] Emit ES-module output for parity with Vite"
+```
+
+---
+
+## Final verification
+
+- [ ] **Full gate**
+
+Run: `pnpm test && pnpm exec oxlint assets/src assets/test && pnpm fmt:check && pnpm build`
+Expected: PASS.
+
+- [ ] **Spec cross-check (Phase 1 slice of the spec)**
+
+Confirm against `docs/superpowers/specs/2026-07-11-twig-asset-tags-design.md` §A: build references relative (no leading slash); dev absolute unchanged; SRI keyed by reference; `manifest.json` unchanged; both bundlers ESM (or the ESM decision escalated per Task 2's gate). The CDN reframe *docs* and the PHP renderer live in Phase 2.

--- a/docs/superpowers/plans/2026-07-12-twig-asset-tags-phase2a-renderer.md
+++ b/docs/superpowers/plans/2026-07-12-twig-asset-tags-phase2a-renderer.md
@@ -1,0 +1,588 @@
+# Twig Asset Tags — Phase 2a (PHP renderer core) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `{{ reprise_entry_script_tags('app') }}` / `reprise_entry_link_tags` / `reprise_entry_js_files` / `reprise_entry_css_files` render the `<script type="module">` / `<link rel="stylesheet">` tags for an entry, resolving each entrypoints.json reference through Symfony `Packages` (ADR 0001) and adding SRI `integrity`/`crossorigin` when present.
+
+**Architecture:** A `TagRenderer` (in `src/Asset/`) consumes the existing `EntrypointsLookupInterface` plus Symfony's `Packages`, resolves each reference via `Packages::getUrl($ref, $packageName ?? $defaultPackage)`, and builds the tag HTML (modelled on WebpackEncoreBundle's `TagRenderer`). A Twig extension exposes the four `reprise_entry_*` functions. The bundle wires it up and adds config (`asset_package`, `crossorigin`, `script_attributes`, `link_attributes`). Dev-HMR injection, `modulepreload`, and WebLink are Phase 2b.
+
+**Tech Stack:** PHP 8.4, Symfony (framework-bundle, asset, config, dependency-injection, http-kernel), Twig, PHPUnit.
+
+## Global Constraints
+
+- PHP style: `final` classes, `readonly` constructor-promoted props; validate untrusted input in factories (loose `array<mixed,mixed>` in, precise types out, no `@var`); `@internal` on implementations, not on the public interface; wirable-by-interface.
+- Symfony license header on every new `.php` file (copy from an existing `src/` file verbatim), `@author Hugo Alliaume <hugo@alliau.me>`.
+- Entrypoints references are docroot-relative in build (`build/app-<hash>.js`, from Phase 1); the renderer resolves them via `Packages`, never renders them as-is.
+- The Reprise asset package must have no version strategy (files are pre-hashed). `reprise.asset_package` names a `framework.assets` package; unset -> framework default package.
+- SRI: add `integrity` when `getIntegrityData()[$reference]` exists; add `crossorigin="anonymous"` alongside it (unless `crossorigin` config says otherwise).
+- Commit scope `[Twig]`.
+- QA gates: `vendor/bin/phpunit`, `vendor/bin/phpstan analyse` (level max), `vendor/bin/php-cs-fixer fix --dry-run`. Run the JS suite too only if JS changes (this plan is PHP-only except Task 1's fixture).
+
+---
+
+## Task 1: Align the PHP entrypoints fixture with the Phase-1 relative format
+
+**Files:**
+- Modify: `tests/fixtures/build/entrypoints.json`
+- Modify: `tests/Asset/EntrypointsLookupFunctionalTest.php`
+
+**Interfaces:**
+- Produces: the build fixture carries docroot-relative references (`build/app-a1b2.js`), matching what the JS plugin now emits, so the renderer's Packages resolution is exercised realistically.
+
+- [ ] **Step 1: Read the current fixture and test**
+
+Read `tests/fixtures/build/entrypoints.json` and `tests/Asset/EntrypointsLookupFunctionalTest.php`. The fixture currently holds final URLs (`/build/app-a1b2.js`); the test asserts `['/build/app-a1b2.js']`.
+
+- [ ] **Step 2: Update the fixture to relative references**
+
+In `tests/fixtures/build/entrypoints.json`, strip the leading slash from every reference under `entryPoints.*.{js,css,preload,dynamic}` and from every `integrity` key (so `/build/app-a1b2.js` -> `build/app-a1b2.js`). Leave `isProd`, `publicPath`, `devServer` as they are.
+
+- [ ] **Step 3: Update the lookup functional test assertions**
+
+In `tests/Asset/EntrypointsLookupFunctionalTest.php`, change both `assertSame(['/build/app-a1b2.js'], …)` to `assertSame(['build/app-a1b2.js'], …)`.
+
+- [ ] **Step 4: Run the PHP suite**
+
+Run: `vendor/bin/phpunit`
+Expected: PASS (the lookup returns the fixture's references verbatim; only the expected strings changed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/fixtures/build/entrypoints.json tests/Asset/EntrypointsLookupFunctionalTest.php
+git commit -m "[Twig] Align the PHP entrypoints fixture with relative references"
+```
+
+---
+
+## Task 2: `TagRenderer` — script/link tags via Packages + SRI
+
+**Files:**
+- Create: `src/Asset/TagRenderer.php`
+- Test: `tests/Asset/TagRendererTest.php`
+
+**Interfaces:**
+- Consumes: `EntrypointsLookupInterface` (existing: `getJavaScriptFiles/getCssFiles(string): list<string>`, `getIntegrityData(): array<string,string>`, `getDevServer(): ?DevServer`, `reset()`), `Symfony\Component\Asset\Packages`.
+- Produces:
+  - `renderScriptTags(string $entryName, ?string $packageName = null): string`
+  - `renderLinkTags(string $entryName, ?string $packageName = null): string`
+  - `getJsFiles(string $entryName, ?string $packageName = null): list<string>`
+  - `getCssFiles(string $entryName, ?string $packageName = null): list<string>`
+  - `reset(): void`
+  Constructor: `__construct(EntrypointsLookupInterface $lookup, Packages $packages, ?string $defaultPackage = null, string|false $crossorigin = false, array $scriptAttributes = [], array $linkAttributes = [])`.
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `tests/Asset/TagRendererTest.php`. Use a hand-rolled fake lookup and a real `Packages` with a `PathPackage('/', new EmptyVersionStrategy())` so `getUrl('build/app.js')` -> `/build/app.js`. (Read `tests/Asset/EntrypointsLookupTest.php` for the license header to copy.)
+
+```php
+<?php
+
+// <license header copied from an existing src/ file>
+
+namespace Symfony\Reprise\Tests\Asset;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Asset\Package;
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\Asset\PathPackage;
+use Symfony\Component\Asset\VersionStrategy\EmptyVersionStrategy;
+use Symfony\Reprise\Asset\DevServer;
+use Symfony\Reprise\Asset\EntrypointsLookupInterface;
+use Symfony\Reprise\Asset\TagRenderer;
+
+final class TagRendererTest extends TestCase
+{
+    private function renderer(
+        array $js = [],
+        array $css = [],
+        array $integrity = [],
+        ?DevServer $devServer = null,
+        string|false $crossorigin = false,
+        array $scriptAttributes = [],
+        array $linkAttributes = [],
+    ): TagRenderer {
+        $lookup = new class($js, $css, $integrity, $devServer) implements EntrypointsLookupInterface {
+            public function __construct(
+                private array $js,
+                private array $css,
+                private array $integrity,
+                private ?DevServer $devServer,
+            ) {
+            }
+
+            public function getJavaScriptFiles(string $entryName): array { return $this->js; }
+            public function getCssFiles(string $entryName): array { return $this->css; }
+            public function getPreloadFiles(string $entryName): array { return []; }
+            public function getDynamicFiles(string $entryName): array { return []; }
+            public function entryExists(string $entryName): bool { return true; }
+            public function getIntegrityData(): array { return $this->integrity; }
+            public function isProd(): bool { return null === $this->devServer; }
+            public function getDevServer(): ?DevServer { return $this->devServer; }
+            public function reset(): void {}
+        };
+
+        $packages = new Packages(new PathPackage('/', new EmptyVersionStrategy()));
+
+        return new TagRenderer($lookup, $packages, null, $crossorigin, $scriptAttributes, $linkAttributes);
+    }
+
+    public function testRendersModuleScriptTagsWithPackagesResolvedSrc(): void
+    {
+        $html = $this->renderer(js: ['build/app-a1b2.js'])->renderScriptTags('app');
+        $this->assertSame('<script src="/build/app-a1b2.js" type="module"></script>', $html);
+    }
+
+    public function testRendersStylesheetLinkTags(): void
+    {
+        $html = $this->renderer(css: ['build/app-c3.css'])->renderLinkTags('app');
+        $this->assertSame('<link rel="stylesheet" href="/build/app-c3.css">', $html);
+    }
+
+    public function testAddsIntegrityAndCrossoriginWhenPresent(): void
+    {
+        $html = $this->renderer(
+            js: ['build/app-a1b2.js'],
+            integrity: ['build/app-a1b2.js' => 'sha384-XYZ'],
+        )->renderScriptTags('app');
+        $this->assertStringContainsString('integrity="sha384-XYZ"', $html);
+        $this->assertStringContainsString('crossorigin="anonymous"', $html);
+    }
+
+    public function testNoCrossoriginWithoutIntegrity(): void
+    {
+        $html = $this->renderer(js: ['build/app-a1b2.js'])->renderScriptTags('app');
+        $this->assertStringNotContainsString('crossorigin', $html);
+    }
+
+    public function testGetJsFilesReturnsResolvedUrlsWithoutTags(): void
+    {
+        $urls = $this->renderer(js: ['build/app-a1b2.js', 'build/vendor-e5.js'])->getJsFiles('app');
+        $this->assertSame(['/build/app-a1b2.js', '/build/vendor-e5.js'], $urls);
+    }
+
+    public function testScriptAndLinkDefaultAttributesAreApplied(): void
+    {
+        $html = $this->renderer(js: ['build/app.js'], scriptAttributes: ['defer' => true])->renderScriptTags('app');
+        $this->assertStringContainsString(' defer', $html);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `vendor/bin/phpunit --filter TagRendererTest`
+Expected: FAIL — `Symfony\Reprise\Asset\TagRenderer` does not exist.
+
+- [ ] **Step 3: Implement `src/Asset/TagRenderer.php`**
+
+```php
+<?php
+
+// <license header copied from an existing src/ file>
+
+namespace Symfony\Reprise\Asset;
+
+use Symfony\Component\Asset\Packages;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * Renders the <script>/<link> tags for an entry, resolving each entrypoints.json reference through
+ * Symfony's asset Packages (ADR 0001) and adding SRI integrity/crossorigin when present.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class TagRenderer implements ResetInterface
+{
+    /**
+     * @param array<string, mixed> $scriptAttributes
+     * @param array<string, mixed> $linkAttributes
+     */
+    public function __construct(
+        private readonly EntrypointsLookupInterface $lookup,
+        private readonly Packages $packages,
+        private readonly ?string $defaultPackage = null,
+        private readonly string|false $crossorigin = false,
+        private readonly array $scriptAttributes = [],
+        private readonly array $linkAttributes = [],
+    ) {
+    }
+
+    public function renderScriptTags(string $entryName, ?string $packageName = null): string
+    {
+        $integrity = $this->lookup->getIntegrityData();
+        $tags = [];
+        foreach ($this->lookup->getJavaScriptFiles($entryName) as $reference) {
+            $attributes = ['src' => $this->url($reference, $packageName), 'type' => 'module'];
+            $attributes += $this->scriptAttributes;
+            $this->applyIntegrity($attributes, $reference, $integrity);
+            $tags[] = \sprintf('<script %s></script>', $this->attributes($attributes));
+        }
+
+        return implode('', $tags);
+    }
+
+    public function renderLinkTags(string $entryName, ?string $packageName = null): string
+    {
+        $integrity = $this->lookup->getIntegrityData();
+        $tags = [];
+        foreach ($this->lookup->getCssFiles($entryName) as $reference) {
+            $attributes = ['rel' => 'stylesheet', 'href' => $this->url($reference, $packageName)];
+            $attributes += $this->linkAttributes;
+            $this->applyIntegrity($attributes, $reference, $integrity);
+            $tags[] = \sprintf('<link %s>', $this->attributes($attributes));
+        }
+
+        return implode('', $tags);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getJsFiles(string $entryName, ?string $packageName = null): array
+    {
+        return array_map(fn (string $r) => $this->url($r, $packageName), $this->lookup->getJavaScriptFiles($entryName));
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getCssFiles(string $entryName, ?string $packageName = null): array
+    {
+        return array_map(fn (string $r) => $this->url($r, $packageName), $this->lookup->getCssFiles($entryName));
+    }
+
+    public function reset(): void
+    {
+        // No per-request state yet (dev-HMR injection is Phase 2b). The lookup owns reference dedup.
+    }
+
+    private function url(string $reference, ?string $packageName): string
+    {
+        return $this->packages->getUrl($reference, $packageName ?? $this->defaultPackage);
+    }
+
+    /**
+     * @param array<string, mixed>  $attributes
+     * @param array<string, string> $integrity
+     */
+    private function applyIntegrity(array &$attributes, string $reference, array $integrity): void
+    {
+        if (!isset($integrity[$reference])) {
+            return;
+        }
+        $attributes['integrity'] = $integrity[$reference];
+        $attributes['crossorigin'] = false === $this->crossorigin ? 'anonymous' : $this->crossorigin;
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    private function attributes(array $attributes): string
+    {
+        $attributes = array_filter($attributes, static fn ($v) => false !== $v);
+
+        return implode(' ', array_map(
+            static fn (string $k, $v) => true === $v || null === $v ? $k : \sprintf('%s="%s"', $k, htmlspecialchars((string) $v, \ENT_QUOTES)),
+            array_keys($attributes),
+            $attributes,
+        ));
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `vendor/bin/phpunit --filter TagRendererTest`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: PHP QA + commit**
+
+Run: `vendor/bin/php-cs-fixer fix src/Asset/TagRenderer.php tests/Asset/TagRendererTest.php` then `vendor/bin/phpstan analyse` and `vendor/bin/phpunit`.
+
+```bash
+git add src/Asset/TagRenderer.php tests/Asset/TagRendererTest.php
+git commit -m "[Twig] Add TagRenderer resolving entry references through Packages"
+```
+
+---
+
+## Task 3: Twig extension + DI wiring + config options
+
+**Files:**
+- Create: `src/Twig/AssetExtension.php`
+- Modify: `src/RepriseBundle.php`
+- Test: `tests/Twig/AssetExtensionTest.php`
+
+**Interfaces:**
+- Consumes: `TagRenderer` (Task 2).
+- Produces: Twig functions `reprise_entry_script_tags(entry, package=null)`, `reprise_entry_link_tags(entry, package=null)`, `reprise_entry_js_files(entry, package=null)`, `reprise_entry_css_files(entry, package=null)`. New config keys `asset_package` (nullable string), `crossorigin` (false|'anonymous'|'use-credentials'), `script_attributes` (array), `link_attributes` (array).
+
+- [ ] **Step 1: Write the failing extension unit test**
+
+Create `tests/Twig/AssetExtensionTest.php`: build a `TagRenderer` (reuse the fake-lookup pattern from `TagRendererTest` — copy the anonymous-class lookup) and assert the extension's functions delegate to it.
+
+```php
+// header + namespace Symfony\Reprise\Tests\Twig;
+// use the same fake lookup + real Packages(PathPackage('/', EmptyVersionStrategy)) as TagRendererTest
+final class AssetExtensionTest extends TestCase
+{
+    public function testExposesTheFourRepriseFunctions(): void
+    {
+        $ext = new AssetExtension($this->tagRenderer(js: ['build/app.js']));
+        $names = array_map(fn ($f) => $f->getName(), $ext->getFunctions());
+        sort($names);
+        $this->assertSame(
+            ['reprise_entry_css_files', 'reprise_entry_js_files', 'reprise_entry_link_tags', 'reprise_entry_script_tags'],
+            $names,
+        );
+    }
+
+    public function testScriptTagsFunctionDelegatesToTheRenderer(): void
+    {
+        $ext = new AssetExtension($this->tagRenderer(js: ['build/app-a1b2.js']));
+        $this->assertSame('<script src="/build/app-a1b2.js" type="module"></script>', $ext->scriptTags('app'));
+    }
+
+    public function testTagFunctionsAreMarkedHtmlSafe(): void
+    {
+        $ext = new AssetExtension($this->tagRenderer());
+        foreach ($ext->getFunctions() as $fn) {
+            if (str_ends_with($fn->getName(), '_tags')) {
+                $this->assertContains('html', $fn->getSafe(new \Twig\Node\Node()) ?: []);
+            }
+        }
+    }
+}
+```
+
+(`tagRenderer(...)` is a small helper that builds a `TagRenderer` the same way `TagRendererTest::renderer` does — copy it.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `vendor/bin/phpunit --filter AssetExtensionTest`
+Expected: FAIL — `Symfony\Reprise\Twig\AssetExtension` does not exist.
+
+- [ ] **Step 3: Implement `src/Twig/AssetExtension.php`**
+
+```php
+<?php
+
+// <license header>
+
+namespace Symfony\Reprise\Twig;
+
+use Symfony\Reprise\Asset\TagRenderer;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Exposes the reprise_entry_* Twig functions.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class AssetExtension extends AbstractExtension
+{
+    public function __construct(private readonly TagRenderer $tagRenderer)
+    {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('reprise_entry_script_tags', $this->scriptTags(...), ['is_safe' => ['html']]),
+            new TwigFunction('reprise_entry_link_tags', $this->linkTags(...), ['is_safe' => ['html']]),
+            new TwigFunction('reprise_entry_js_files', $this->jsFiles(...)),
+            new TwigFunction('reprise_entry_css_files', $this->cssFiles(...)),
+        ];
+    }
+
+    public function scriptTags(string $entryName, ?string $packageName = null): string
+    {
+        return $this->tagRenderer->renderScriptTags($entryName, $packageName);
+    }
+
+    public function linkTags(string $entryName, ?string $packageName = null): string
+    {
+        return $this->tagRenderer->renderLinkTags($entryName, $packageName);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function jsFiles(string $entryName, ?string $packageName = null): array
+    {
+        return $this->tagRenderer->getJsFiles($entryName, $packageName);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function cssFiles(string $entryName, ?string $packageName = null): array
+    {
+        return $this->tagRenderer->getCssFiles($entryName, $packageName);
+    }
+}
+```
+
+- [ ] **Step 4: Run the extension test to verify it passes**
+
+Run: `vendor/bin/phpunit --filter AssetExtensionTest`
+Expected: PASS.
+
+- [ ] **Step 5: Add config keys + wire the services in `src/RepriseBundle.php`**
+
+In `configure()`, add under the existing children (after `strict_mode`):
+
+```php
+                ->scalarNode('asset_package')
+                    ->defaultNull()
+                    ->info('Name of a framework.assets package used to resolve entry URLs (must have no version strategy). Null uses the default package.')
+                ->end()
+                ->scalarNode('crossorigin')
+                    ->defaultFalse()
+                    ->info('crossorigin attribute added alongside SRI integrity: false, "anonymous", or "use-credentials".')
+                ->end()
+                ->arrayNode('script_attributes')
+                    ->normalizeKeys(false)->variablePrototype()->end()->defaultValue([])
+                    ->info('Default attributes added to every <script> tag.')
+                ->end()
+                ->arrayNode('link_attributes')
+                    ->normalizeKeys(false)->variablePrototype()->end()->defaultValue([])
+                    ->info('Default attributes added to every <link> tag.')
+                ->end()
+```
+
+Update the `loadExtension` `@param` phpdoc shape to include the new keys, then register the services (after the existing `reprise.entrypoints_lookup` / reset listener):
+
+```php
+        $services->set('reprise.tag_renderer', TagRenderer::class)
+            ->args([
+                service('reprise.entrypoints_lookup'),
+                service('assets.packages'),
+                $config['asset_package'],
+                $config['crossorigin'],
+                $config['script_attributes'],
+                $config['link_attributes'],
+            ])
+            ->tag('kernel.reset', ['method' => 'reset'])
+        ;
+
+        $services->set('reprise.twig_extension', AssetExtension::class)
+            ->args([service('reprise.tag_renderer')])
+            ->tag('twig.extension')
+        ;
+```
+
+Add the imports (`use Symfony\Reprise\Asset\TagRenderer; use Symfony\Reprise\Twig\AssetExtension;`).
+
+Note: `assets.packages` is the framework `Packages` service; it only exists when `framework.assets` is enabled. That is a documented requirement (Phase 2b docs); the functional test in Task 4 enables it.
+
+- [ ] **Step 6: PHP QA + commit**
+
+Run: `vendor/bin/php-cs-fixer fix src/ tests/Twig/` then `vendor/bin/phpstan analyse` and `vendor/bin/phpunit`.
+
+```bash
+git add src/Twig/AssetExtension.php src/RepriseBundle.php tests/Twig/AssetExtensionTest.php
+git commit -m "[Twig] Add the reprise_entry_* Twig functions and wire the renderer"
+```
+
+---
+
+## Task 4: Functional test — render tags through a booted kernel
+
+**Files:**
+- Create: `tests/Kernel/RendererAppKernel.php` (a kernel enabling `framework.assets` + a version-less `reprise` package + `reprise.asset_package: reprise`)
+- Test: `tests/Twig/AssetExtensionFunctionalTest.php`
+
+**Interfaces:**
+- Consumes: the wired `reprise.tag_renderer` + `reprise.twig_extension`, the `build` fixture (Task 1).
+
+- [ ] **Step 1: Write the failing functional test**
+
+Read `tests/Kernel/FrameworkAppKernel.php` and `tests/Asset/EntrypointsLookupFunctionalTest.php` for the exact kernel + fixture-path pattern. Create `tests/Kernel/RendererAppKernel.php` mirroring `FrameworkAppKernel` but whose `registerContainerConfiguration` also configures assets and the reprise output_path/package:
+
+```php
+            $container->loadFromExtension('framework', [
+                'secret' => '$ecret',
+                'test' => true,
+                'http_method_override' => false,
+                'assets' => [
+                    'packages' => [
+                        'reprise' => [
+                            'version' => null, // no versioning: Reprise files are already hashed
+                        ],
+                    ],
+                ],
+            ]);
+            $container->loadFromExtension('reprise', [
+                'output_path' => $this->buildDir,
+                'asset_package' => 'reprise',
+            ]);
+```
+
+(The kernel takes the fixture build dir in its constructor like `FunctionalAppKernel`; store it in `$this->buildDir`. Confirm the exact constructor/property pattern by reading `FunctionalAppKernel.php`.)
+
+Create `tests/Twig/AssetExtensionFunctionalTest.php`:
+
+```php
+final class AssetExtensionFunctionalTest extends TestCase
+{
+    public function testScriptTagsRenderThroughTheContainer(): void
+    {
+        $kernel = new RendererAppKernel(__DIR__.'/../fixtures/build');
+        $kernel->boot();
+        $renderer = $kernel->getContainer()->get('reprise.tag_renderer');
+
+        $html = $renderer->renderScriptTags('app');
+        $this->assertStringContainsString('<script ', $html);
+        $this->assertStringContainsString('type="module"', $html);
+        $this->assertStringContainsString('src="/build/app-a1b2.js"', $html); // relative ref -> Packages -> /build/…
+    }
+
+    public function testLinkTagsRenderThroughTheContainer(): void
+    {
+        $kernel = new RendererAppKernel(__DIR__.'/../fixtures/build');
+        $kernel->boot();
+        $renderer = $kernel->getContainer()->get('reprise.tag_renderer');
+
+        $this->assertStringContainsString('rel="stylesheet"', $renderer->renderLinkTags('app'));
+    }
+}
+```
+
+Make `reprise.tag_renderer` fetchable in the test: either mark it public in a test-only pass, or fetch it via `$kernel->getContainer()->get()` in a `test` env (services are public in the test container when fetched through `getContainer()` on a `test`-enabled kernel; confirm by mirroring how `EntrypointsLookupFunctionalTest` fetches `EntrypointsLookupInterface`). If the service is private, add `->public()` to `reprise.tag_renderer` in `loadExtension`, or fetch via the `EntrypointsLookupInterface`-style alias.
+
+- [ ] **Step 2: Run to verify it fails, then implement/adjust, then passes**
+
+Run: `vendor/bin/phpunit --filter AssetExtensionFunctionalTest`
+Expected: FAIL first (kernel/service wiring), then PASS once the kernel + service visibility are correct. If `assets.packages` is missing, confirm `framework.assets` is enabled in the kernel; if the service is private, make `reprise.tag_renderer` public.
+
+- [ ] **Step 3: Full PHP suite + QA**
+
+Run: `vendor/bin/phpunit && vendor/bin/phpstan analyse && vendor/bin/php-cs-fixer fix --dry-run`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/Kernel/RendererAppKernel.php tests/Twig/AssetExtensionFunctionalTest.php src/RepriseBundle.php
+git commit -m "[Twig] Cover tag rendering end-to-end through a booted kernel"
+```
+
+---
+
+## Final verification
+
+- [ ] **Full PHP gate**
+
+Run: `vendor/bin/phpunit && vendor/bin/phpstan analyse && vendor/bin/php-cs-fixer fix --dry-run && composer validate --strict`
+Expected: PASS.
+
+- [ ] **Spec cross-check (Phase 2a slice)**
+
+Confirm against `docs/superpowers/specs/2026-07-11-twig-asset-tags-design.md` §B/§C: four `reprise_entry_*` functions; `type="module"`; integrity + crossorigin when present; resolution via a `framework.assets` package (`asset_package`, version-less); config keys added. Deferred to Phase 2b (not this plan): dev `@vite/client` injection, `modulepreload`/`preload` rendering, WebLink, and the docs section.

--- a/docs/superpowers/plans/2026-07-12-twig-asset-tags-phase2b-dev-preload-docs.md
+++ b/docs/superpowers/plans/2026-07-12-twig-asset-tags-phase2b-dev-preload-docs.md
@@ -1,0 +1,611 @@
+# Twig Asset Tags — Phase 2b (dev HMR + modulepreload + WebLink + docs) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish the Twig asset-tag renderer — dev-server HMR client injection, `modulepreload` hints for preload chunks, optional WebLink `Link:` headers — and document the whole feature (a new "Rendering asset tags" section plus a CDN reframe around `framework.assets`).
+
+**Architecture:** Extends the existing `TagRenderer` (Phase 2a) in place. `renderScriptTags` gains two responsibilities before emitting the entry scripts: inject the Vite HMR client once per request in dev, and emit `<link rel="modulepreload">` for the entry's preload chunks. A new optional WebLink hook registers preloadable references on the current request so `AddLinkHeaderListener` turns them into `Link:` headers. Docs follow.
+
+**Tech Stack:** PHP 8.4, Symfony bundle (`AbstractBundle`), `symfony/asset` `Packages`, `symfony/web-link` (optional), Twig, PHPUnit 13, PHPStan max, php-cs-fixer.
+
+## Global Constraints
+
+- PHP: `final` classes, `readonly` promoted constructor props; Symfony license header + `@author Hugo Alliaume <hugo@alliau.me>` on every new `.php`; `@internal` on implementations, never on the public interface.
+- Entry references are always resolved through `Packages::getUrl()` — never emitted as-is. A dev absolute URL (`http://…/build/app.js`) passes through `Packages` unchanged.
+- Dev HMR client injection is **Vite-only**: inject `<script type="module" src="{origin}/@vite/client"></script>` when `devServer.client === 'vite'`. Rsbuild dev emits `client: null` (its HMR client is compiled into the bundle) → inject nothing. This asymmetry is by design; both bundlers get a functional test (Vite injects, Rsbuild is the off case).
+- `modulepreload` is for `getPreloadFiles()` references only; `dynamic` chunks are never rendered.
+- SRI: when `getIntegrityData()[$reference]` exists, add `integrity="…"` + `crossorigin` (`anonymous` unless `crossorigin` is configured otherwise). The dev integrity map is empty, so no SRI in dev.
+- WebLink is an **optional** dependency: every WebLink code path is guarded by `class_exists(GenericLinkProvider::class)` and a present current request; it is a silent no-op otherwise.
+- Per-request state (`clientInjected` flag) is cleared by `TagRenderer::reset()`, already wired through `kernel.reset`.
+- Bundler test symmetry: any functional test for one bundler ships with its equivalent (or documented off-case) for the other.
+- Docs: any user-facing feature ships a `doc/index.rst` section with **both** a Vite and an Rsbuild example. Prose drafted/polished via the `natural-writing-editor` agent. ASCII `->`, never `→`.
+- QA gate per task: `vendor/bin/phpunit`, `vendor/bin/phpstan analyse`, `vendor/bin/php-cs-fixer fix`.
+
+---
+
+## File Structure
+
+- `src/Asset/TagRenderer.php` — modified across Tasks 1–3 (HMR flag, modulepreload loop, WebLink hook + two new constructor args).
+- `src/RepriseBundle.php` — modified in Task 3 (new `preload` config key, `request_stack` + `preload` service args, updated config docblock).
+- `composer.json` — modified in Task 3 (`symfony/web-link` added to `require-dev`).
+- `tests/Asset/TagRendererTest.php` — modified across Tasks 1–3 (unit tests; the `renderer()` helper gains `preload`, `requestStack`, `preloadEnabled` params and updates the `new TagRenderer(...)` call).
+- `tests/fixtures/dev/entrypoints.json` — the existing Vite dev fixture (`client: "vite"`); used by Task 4. Unused by any test today.
+- `tests/fixtures/dev-rspack/entrypoints.json` — created in Task 4 (Rsbuild dev fixture, `client: null`).
+- `tests/Functional/DevAssetTagsTest.php` — created in Task 4 (dev-mode E2E for both bundlers).
+- `tests/Functional/AssetTagsTest.php` — modified in Task 2 (the `app` prod entry now emits a `modulepreload` link before its script).
+- `doc/index.rst`, `README.md` — modified in Task 5 (new section, CDN reframe, feature markers).
+
+---
+
+### Task 1: Dev HMR client injection
+
+Inject the Vite HMR client once per request at the top of `renderScriptTags`, gated on `devServer.client === 'vite'`, cleared by `reset()`. No DI or constructor change.
+
+**Files:**
+- Modify: `src/Asset/TagRenderer.php`
+- Test: `tests/Asset/TagRendererTest.php`
+
+**Interfaces:**
+- Consumes: `EntrypointsLookupInterface::getDevServer(): ?DevServer`; `DevServer { public readonly string $origin; public readonly ?string $client; }` (`client` is `'vite'` for Vite dev, `null` for Rsbuild dev, absent/null in prod).
+- Produces: no signature change. Adds private state `bool $clientInjected`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/Asset/TagRendererTest.php`:
+
+```php
+    public function testInjectsViteHmrClientOncePerRequestInDev()
+    {
+        $renderer = $this->renderer(
+            js: ['http://127.0.0.1:5173/build/app.js'],
+            devServer: new DevServer('http://127.0.0.1:5173', 'vite'),
+        );
+
+        $first = $renderer->renderScriptTags('app');
+        $this->assertSame(
+            '<script type="module" src="http://127.0.0.1:5173/@vite/client"></script>'
+            .'<script src="http://127.0.0.1:5173/build/app.js" type="module"></script>',
+            $first,
+        );
+
+        // Same request, second call (e.g. a second entry): the client is not injected again.
+        $second = $renderer->renderScriptTags('app');
+        $this->assertStringNotContainsString('@vite/client', $second);
+
+        // A new request resets the flag and the client is injected again.
+        $renderer->reset();
+        $this->assertStringContainsString('@vite/client', $renderer->renderScriptTags('app'));
+    }
+
+    public function testDoesNotInjectHmrClientWhenDevServerClientIsNull()
+    {
+        $html = $this->renderer(
+            js: ['http://127.0.0.1:5173/build/app.js'],
+            devServer: new DevServer('http://127.0.0.1:5173', null),
+        )->renderScriptTags('app');
+
+        $this->assertStringNotContainsString('@vite/client', $html);
+    }
+
+    public function testDoesNotInjectHmrClientInProd()
+    {
+        $html = $this->renderer(js: ['build/app-a1b2.js'])->renderScriptTags('app');
+
+        $this->assertStringNotContainsString('@vite/client', $html);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `vendor/bin/phpunit --filter 'HmrClient|InjectsViteHmr' tests/Asset/TagRendererTest.php`
+Expected: FAIL — the `@vite/client` script is not emitted yet.
+
+- [ ] **Step 3: Implement the injection**
+
+In `src/Asset/TagRenderer.php`, add the private flag right after the class opening brace:
+
+```php
+    private bool $clientInjected = false;
+```
+
+Rewrite the top of `renderScriptTags` so the HMR client is prepended before the script loop (leave the existing `$integrity`/`$tags` setup and the `foreach (getJavaScriptFiles …)` loop in place):
+
+```php
+    public function renderScriptTags(string $entryName, ?string $packageName = null): string
+    {
+        $integrity = $this->lookup->getIntegrityData();
+        $tags = [];
+
+        $devServer = $this->lookup->getDevServer();
+        if (!$this->clientInjected && null !== $devServer && 'vite' === $devServer->client) {
+            $tags[] = \sprintf('<script type="module" src="%s/@vite/client"></script>', $devServer->origin);
+            $this->clientInjected = true;
+        }
+
+        foreach ($this->lookup->getJavaScriptFiles($entryName) as $reference) {
+            $attributes = ['src' => $this->url($reference, $packageName), 'type' => 'module'];
+            $attributes += $this->scriptAttributes;
+            $this->applyIntegrity($attributes, $reference, $integrity);
+            $tags[] = \sprintf('<script %s></script>', $this->attributes($attributes));
+        }
+
+        return implode('', $tags);
+    }
+```
+
+Update `reset()` to clear the flag (replace the Phase-2a no-op body):
+
+```php
+    public function reset(): void
+    {
+        $this->clientInjected = false;
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `vendor/bin/phpunit tests/Asset/TagRendererTest.php`
+Expected: PASS (all TagRenderer unit tests green).
+
+- [ ] **Step 5: QA + commit**
+
+```bash
+vendor/bin/php-cs-fixer fix src/Asset/TagRenderer.php tests/Asset/TagRendererTest.php
+vendor/bin/phpstan analyse
+git add src/Asset/TagRenderer.php tests/Asset/TagRendererTest.php
+git commit -m "[Twig] Inject the Vite HMR client once per request in dev"
+```
+
+---
+
+### Task 2: modulepreload hints for preload chunks
+
+Emit `<link rel="modulepreload" href="…">` (with SRI when present) for each `getPreloadFiles()` reference, between the HMR client and the entry scripts.
+
+**Files:**
+- Modify: `src/Asset/TagRenderer.php`
+- Test: `tests/Asset/TagRendererTest.php`, `tests/Functional/AssetTagsTest.php`
+
+**Interfaces:**
+- Consumes: `EntrypointsLookupInterface::getPreloadFiles(string): list<string>`.
+- Produces: no signature change.
+
+- [ ] **Step 1: Extend the test helper to drive preload files**
+
+In `tests/Asset/TagRendererTest.php`, add a `preload` parameter to the `renderer()` helper and return it from the anonymous lookup's `getPreloadFiles()`.
+
+Change the helper signature (add `array $preload = []` after `array $css = []`):
+
+```php
+    private function renderer(
+        array $js = [],
+        array $css = [],
+        array $preload = [],
+        array $integrity = [],
+        ?DevServer $devServer = null,
+        string|false $crossorigin = false,
+        array $scriptAttributes = [],
+        array $linkAttributes = [],
+    ): TagRenderer {
+```
+
+Add `private array $preload` to the anonymous class constructor and pass `$preload` into it (mirror the existing `$js`/`$css` wiring), then make `getPreloadFiles` return it:
+
+```php
+            public function getPreloadFiles(string $entryName): array
+            {
+                return $this->preload;
+            }
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```php
+    public function testRendersModulepreloadLinksWithIntegrityBeforeScripts()
+    {
+        $html = $this->renderer(
+            js: ['build/app-a1b2.js'],
+            preload: ['build/shared-e5.js'],
+            integrity: ['build/shared-e5.js' => 'sha384-shared'],
+        )->renderScriptTags('app');
+
+        $this->assertSame(
+            '<link rel="modulepreload" href="/build/shared-e5.js" integrity="sha384-shared" crossorigin="anonymous">'
+            .'<script src="/build/app-a1b2.js" type="module"></script>',
+            $html,
+        );
+    }
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `vendor/bin/phpunit --filter Modulepreload tests/Asset/TagRendererTest.php`
+Expected: FAIL — no `modulepreload` link emitted yet.
+
+- [ ] **Step 4: Implement the modulepreload loop**
+
+In `src/Asset/TagRenderer.php`, insert the preload loop in `renderScriptTags` between the HMR-client block and the `getJavaScriptFiles` loop:
+
+```php
+        foreach ($this->lookup->getPreloadFiles($entryName) as $reference) {
+            $attributes = ['rel' => 'modulepreload', 'href' => $this->url($reference, $packageName)];
+            $this->applyIntegrity($attributes, $reference, $integrity);
+            $tags[] = \sprintf('<link %s>', $this->attributes($attributes));
+        }
+```
+
+- [ ] **Step 5: Update the prod functional assertion**
+
+The `app` entry in `tests/fixtures/build/entrypoints.json` has `preload: ["build/shared-e5f6.js"]` with `integrity["build/shared-e5f6.js"] = "sha384-shared"`, so `renderScriptTags('app')` now emits a `modulepreload` link before the script. Update the expected heredoc in `tests/Functional/AssetTagsTest.php::testScriptTagsRenderTheEntryWithResolvedUrlAndIntegrity`:
+
+```php
+        $expected = <<<'HTML'
+            <link rel="modulepreload" href="/build/shared-e5f6.js" integrity="sha384-shared" crossorigin="anonymous"><script src="/build/app-a1b2.js" type="module" integrity="sha384-app" crossorigin="anonymous"></script>
+            HTML;
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `vendor/bin/phpunit tests/Asset/TagRendererTest.php tests/Functional/AssetTagsTest.php`
+Expected: PASS.
+
+- [ ] **Step 7: QA + commit**
+
+```bash
+vendor/bin/php-cs-fixer fix src tests
+vendor/bin/phpstan analyse
+git add src/Asset/TagRenderer.php tests/Asset/TagRendererTest.php tests/Functional/AssetTagsTest.php
+git commit -m "[Twig] Emit modulepreload hints for an entry's preload chunks"
+```
+
+---
+
+### Task 3: WebLink `Link:` header registration (optional)
+
+When `symfony/web-link` is installed and a request is in flight, register each rendered reference on the request's `_links` provider so `AddLinkHeaderListener` emits `Link:` headers. Gated by a `reprise.preload` config toggle (default on).
+
+**Files:**
+- Modify: `composer.json`, `src/Asset/TagRenderer.php`, `src/RepriseBundle.php`
+- Test: `tests/Asset/TagRendererTest.php`
+
+**Interfaces:**
+- Consumes: `Symfony\Component\HttpFoundation\RequestStack`; `Symfony\Component\WebLink\{Link, GenericLinkProvider}`.
+- Produces: new `TagRenderer` constructor signature — `__construct(EntrypointsLookupInterface $lookup, Packages $packages, ?RequestStack $requestStack = null, ?string $defaultPackage = null, string|false $crossorigin = false, bool $preload = true, array $scriptAttributes = [], array $linkAttributes = [])`. New Reprise config key `preload` (bool, default true).
+
+- [ ] **Step 1: Add web-link to require-dev**
+
+```bash
+composer require --dev "symfony/web-link:^7.4|^8.0"
+```
+
+Confirm `composer.json`'s `require-dev` now lists `symfony/web-link`. (If offline, add `"symfony/web-link": "^7.4|^8.0"` to `require-dev` by hand and run `composer update symfony/web-link`.)
+
+- [ ] **Step 2: Update the test helper for requestStack + preload toggle**
+
+In `tests/Asset/TagRendererTest.php`, add `?RequestStack $requestStack = null` and `bool $preloadEnabled = true` to the `renderer()` helper signature (after `array $linkAttributes = []`), add the `use` imports, and update the `new TagRenderer(...)` construction to the new arg order:
+
+```php
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\WebLink\GenericLinkProvider;
+```
+
+```php
+        return new TagRenderer(
+            $lookup,
+            $packages,
+            $requestStack,
+            null,
+            $crossorigin,
+            $preloadEnabled,
+            $scriptAttributes,
+            $linkAttributes,
+        );
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+```php
+    public function testRegistersPreloadLinksOnTheRequestWhenWebLinkIsAvailable()
+    {
+        $stack = new RequestStack();
+        $stack->push($request = new Request());
+
+        $renderer = $this->renderer(
+            js: ['build/app-a1b2.js'],
+            css: ['build/app-c3.css'],
+            preload: ['build/shared-e5.js'],
+            requestStack: $stack,
+        );
+        $renderer->renderScriptTags('app');
+        $renderer->renderLinkTags('app');
+
+        $links = $request->attributes->get('_links');
+        $this->assertInstanceOf(GenericLinkProvider::class, $links);
+
+        $byHref = [];
+        foreach ($links->getLinks() as $link) {
+            $byHref[$link->getHref()] = ['rels' => $link->getRels(), 'as' => $link->getAttributes()['as'] ?? null];
+        }
+
+        $this->assertSame(['modulepreload'], $byHref['/build/shared-e5.js']['rels']);
+        $this->assertSame(['preload'], $byHref['/build/app-a1b2.js']['rels']);
+        $this->assertSame('script', $byHref['/build/app-a1b2.js']['as']);
+        $this->assertSame(['preload'], $byHref['/build/app-c3.css']['rels']);
+        $this->assertSame('style', $byHref['/build/app-c3.css']['as']);
+    }
+
+    public function testDoesNotRegisterLinksWithoutACurrentRequest()
+    {
+        $renderer = $this->renderer(js: ['build/app-a1b2.js'], requestStack: new RequestStack());
+
+        // No current request pushed: rendering must not throw and returns the tags as usual.
+        $this->assertStringContainsString('<script', $renderer->renderScriptTags('app'));
+    }
+
+    public function testPreloadToggleDisablesLinkRegistration()
+    {
+        $stack = new RequestStack();
+        $stack->push($request = new Request());
+
+        $this->renderer(js: ['build/app-a1b2.js'], requestStack: $stack, preloadEnabled: false)
+            ->renderScriptTags('app');
+
+        $this->assertNull($request->attributes->get('_links'));
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they fail**
+
+Run: `vendor/bin/phpunit --filter 'Preload|WebLink|RegistersPreload' tests/Asset/TagRendererTest.php`
+Expected: FAIL — constructor does not accept `requestStack`/`preload` and no links are registered.
+
+- [ ] **Step 5: Implement the WebLink hook**
+
+In `src/Asset/TagRenderer.php`, add imports:
+
+```php
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\WebLink\GenericLinkProvider;
+use Symfony\Component\WebLink\Link;
+```
+
+Update the constructor (insert `$requestStack` after `$packages`, `$preload` after `$crossorigin`):
+
+```php
+    public function __construct(
+        private readonly EntrypointsLookupInterface $lookup,
+        private readonly Packages $packages,
+        private readonly ?RequestStack $requestStack = null,
+        private readonly ?string $defaultPackage = null,
+        private readonly string|false $crossorigin = false,
+        private readonly bool $preload = true,
+        private readonly array $scriptAttributes = [],
+        private readonly array $linkAttributes = [],
+    ) {
+    }
+```
+
+Register links from the render loops. In `renderScriptTags`, after building each `modulepreload` link add `$this->preload($this->url($reference, $packageName), 'modulepreload');` and after each entry script add `$this->preload($this->url($reference, $packageName), 'preload', 'script');`. In `renderLinkTags`, after each stylesheet add `$this->preload($this->url($reference, $packageName), 'preload', 'style');`. (Reuse the URL already computed for the tag rather than resolving twice — assign it to a `$url` local in each loop and pass that.)
+
+Add the helper:
+
+```php
+    private function preload(string $url, string $rel, ?string $as = null): void
+    {
+        if (!$this->preload || null === $this->requestStack || !class_exists(GenericLinkProvider::class)) {
+            return;
+        }
+
+        $request = $this->requestStack->getCurrentRequest();
+        if (null === $request) {
+            return;
+        }
+
+        $link = new Link($rel, $url);
+        if (null !== $as) {
+            $link = $link->withAttribute('as', $as);
+        }
+
+        $linkProvider = $request->attributes->get('_links', new GenericLinkProvider());
+        $request->attributes->set('_links', $linkProvider->withLink($link));
+    }
+```
+
+- [ ] **Step 6: Wire the config key + service args**
+
+In `src/RepriseBundle.php`, add the `preload` config node after `strict_mode`:
+
+```php
+                ->booleanNode('preload')
+                    ->defaultTrue()
+                    ->info('Register rendered assets as WebLink Link: headers (HTTP/2 preload). No-op when symfony/web-link is absent.')
+                ->end()
+```
+
+Update the `loadExtension` config-array docblock to include `preload: bool`, and update the `reprise.tag_renderer` service args to the new constructor order:
+
+```php
+        $services->set('reprise.tag_renderer', TagRenderer::class)
+            ->args([
+                service('reprise.entrypoints_lookup'),
+                service('assets.packages'),
+                service('request_stack'),
+                $config['asset_package'],
+                $config['crossorigin'],
+                $config['preload'],
+                $config['script_attributes'],
+                $config['link_attributes'],
+            ])
+            ->tag('kernel.reset', ['method' => 'reset'])
+        ;
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `vendor/bin/phpunit`
+Expected: PASS (full suite — the functional kernel picks up the new `preload` config default and the new service args).
+
+- [ ] **Step 8: QA + commit**
+
+```bash
+vendor/bin/php-cs-fixer fix src tests
+vendor/bin/phpstan analyse
+composer validate --strict
+git add composer.json composer.lock src tests
+git commit -m "[WebLink] Register rendered assets as Link: preload headers"
+```
+
+---
+
+### Task 4: Dev-mode functional coverage for both bundlers
+
+Boot the real kernel against a dev `entrypoints.json` and assert the rendered tags: Vite injects `@vite/client` and serves scripts from the dev-server origin; Rsbuild serves from the origin with no client injection.
+
+**Files:**
+- Create: `tests/fixtures/dev-rspack/entrypoints.json`, `tests/Functional/DevAssetTagsTest.php`
+- Reuse: `tests/fixtures/dev/entrypoints.json` (Vite, `client: "vite"`), `tests/Kernel/FunctionalAppKernel.php`
+
+**Interfaces:**
+- Consumes: `FunctionalAppKernel(string $outputPath)` (exposes `reprise.tag_renderer` publicly).
+
+- [ ] **Step 1: Create the Rsbuild dev fixture**
+
+`tests/fixtures/dev-rspack/entrypoints.json` — same shape as the Vite dev fixture but `client: null`:
+
+```json
+{
+    "isProd": false,
+    "devServer": { "origin": "http://127.0.0.1:3000", "client": null },
+    "publicPath": "/build/",
+    "entryPoints": {
+        "app": {
+            "js": ["http://127.0.0.1:3000/build/app.js"],
+            "css": [],
+            "preload": [],
+            "dynamic": []
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Write the dev functional tests**
+
+`tests/Functional/DevAssetTagsTest.php`:
+
+```php
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Tests\Functional;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Reprise\Asset\TagRenderer;
+use Symfony\Reprise\Tests\Kernel\FunctionalAppKernel;
+
+final class DevAssetTagsTest extends TestCase
+{
+    private function renderer(string $fixture): TagRenderer
+    {
+        $kernel = new FunctionalAppKernel(__DIR__.'/../fixtures/'.$fixture);
+        $kernel->boot();
+
+        return $kernel->getContainer()->get('reprise.tag_renderer');
+    }
+
+    public function testViteDevInjectsTheHmrClientAndServesFromTheOrigin()
+    {
+        // Vite dev emits `client: "vite"`, so the HMR client is injected once, before the entry
+        // script; the script src is the dev-server origin URL, passed through by Packages unchanged.
+        $expected = <<<'HTML'
+            <script type="module" src="http://127.0.0.1:5173/@vite/client"></script><script src="http://127.0.0.1:5173/build/app.js" type="module"></script>
+            HTML;
+
+        $this->assertSame($expected, $this->renderer('dev')->renderScriptTags('app'));
+    }
+
+    public function testRsbuildDevServesFromTheOriginWithNoClientInjection()
+    {
+        // Rsbuild dev emits `client: null` (its HMR client is compiled into the bundle), so nothing
+        // is injected; the entry script still loads from the dev-server origin.
+        $expected = <<<'HTML'
+            <script src="http://127.0.0.1:3000/build/app.js" type="module"></script>
+            HTML;
+
+        $this->assertSame($expected, $this->renderer('dev-rspack')->renderScriptTags('app'));
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they pass**
+
+Run: `vendor/bin/phpunit tests/Functional/DevAssetTagsTest.php`
+Expected: PASS (both bundlers).
+
+- [ ] **Step 4: QA + commit**
+
+```bash
+vendor/bin/php-cs-fixer fix tests
+vendor/bin/phpstan analyse
+git add tests/fixtures/dev-rspack tests/Functional/DevAssetTagsTest.php
+git commit -m "[Tests] Cover dev-mode tag rendering for Vite and Rsbuild"
+```
+
+---
+
+### Task 5: Documentation — Rendering asset tags
+
+Document the feature as an Encore-like experience: a new "Rendering asset tags" section (the four Twig functions, works out of the box) and flipped feature markers. **The existing "Using a CDN" section is left unchanged** — CDN stays the Encore way (`publicPath` set to the CDN URL for the build + `manifestKeyPrefix`), which is what a migrating Encore user already knows and which still works end-to-end under ADR 0001 (an absolute `publicPath` yields absolute refs that `Packages` passes through). Do **not** reframe CDN around `framework.assets`.
+
+**Files:**
+- Modify: `doc/index.rst`, `README.md`
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Draft the "Rendering asset tags" section**
+
+Use the `natural-writing-editor` agent to draft the prose. Insert a new section in `doc/index.rst` after the two bundler setup blocks (after the "Rsbuild" section, before "Symfony UX / Stimulus controllers"). It must contain, in the project's voice, framed as "it just works, like Encore":
+
+- What the feature does: `RepriseBundle` reads `entrypoints.json` and renders the `<script>`/`<link>` tags for an entry in Twig — the same experience as WebpackEncoreBundle's `encore_entry_script_tags`/`encore_entry_link_tags`.
+- The four Twig functions with a usage snippet: `reprise_entry_script_tags('app')` and `reprise_entry_link_tags('app')` in a template `<head>`, plus `reprise_entry_js_files('app')` / `reprise_entry_css_files('app')` (the raw URL lists, for when you need the paths rather than the tags).
+- **No setup required for the common case.** The tags render against Symfony's default asset package, so a standard project needs nothing beyond installing the bundle and setting `output_path` if it differs from the default. The build writes docroot-relative references and the default package resolves them to `/build/...`.
+- The optional Reprise config keys, briefly: `output_path`, `strict_mode`, `crossorigin`, `preload` (WebLink HTTP/2 preload headers), `script_attributes`, `link_attributes`. Write the YAML `reprise:` block with each key on its own line.
+- **Advanced note (short):** `asset_package` lets you resolve URLs through a specific `framework.assets` package instead of the default — needed only if your default package applies a version strategy (which would re-hash the already-hashed Reprise files); point it at a package with `version: false`. Keep this to a couple of sentences; it is not the main flow.
+- For CDN, cross-reference the existing "Using a CDN" section (set `publicPath` to the CDN URL for the build) rather than repeating it.
+- Both bundlers: the Twig side is identical for Vite and Rsbuild, so show that explicitly (one Twig snippet, a note that it is the same regardless of which of the two `vite.config.ts` / `rsbuild.config.ts` setups from above you use). This satisfies the both-bundlers docs convention.
+- The dev-server note: in dev, `reprise_entry_script_tags` injects the Vite HMR client automatically; with Rsbuild the HMR client is bundled in, so nothing extra is emitted — either way there is nothing to configure.
+
+Follow the memory note on doc formatting: write `Symfony({...})` options and the `reprise:` YAML multi-line, one key per line.
+
+- [ ] **Step 2: Flip the feature markers**
+
+In `doc/index.rst` (lines ~16-26) and `README.md` (the feature bullet list), ensure "Dev server & HMR" and the tag-rendering capability read as delivered rather than planned. If a `*(planned)*` marker is present on the relevant bullets, remove it; if the lists carry no such markers, add a bullet naming the Twig tag rendering as a shipped capability. Keep both lists in sync. **Do not touch the "CDN support" or "Subresource Integrity" bullets or the "Using a CDN" section.**
+
+- [ ] **Step 3: Verify the docs lint clean**
+
+Run: `pnpm lint` (the repo lint; `doc/` is ignored by Oxlint, so this only confirms nothing else regressed) and re-read the edited `doc/index.rst` section to confirm the Twig usage is shown, both bundlers are addressed, and the RST code-block directives are well-formed.
+Expected: no errors; the new section is Encore-like and the CDN section is untouched.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add doc/index.rst README.md
+git commit -m "[Docs] Document rendering asset tags in Twig"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** dev HMR (Task 1) ✓; modulepreload (Task 2) ✓; WebLink incl. `reprise.preload` toggle + `as=script`/`as=style` (Task 3) ✓; URL resolution via the default asset package, `asset_package`/`version: false` as an advanced note (documented Task 5, implemented Phase 2a) ✓; dev-mode functional for both bundlers (Task 4) ✓; docs "Rendering asset tags" (Task 5) ✓. **Deviation from spec (user decision):** the spec's "reframe CDN around framework.assets" is NOT done — CDN stays the Encore way (`publicPath` + `manifestKeyPrefix`), for coherence with Encore's own CDN doc; the "Using a CDN" section is left unchanged. Out of scope (unchanged): manifest.json / `asset()`, multi-build, `encore_*` aliases, React refresh preamble, rendering `dynamic` chunks.
+- **Type consistency:** `TagRenderer` constructor final order (lookup, packages, requestStack, defaultPackage, crossorigin, preload, scriptAttributes, linkAttributes) is applied identically in Task 3's class, the `RepriseBundle` service args, and the test helper's `new TagRenderer(...)`. The test helper param order (js, css, preload, integrity, devServer, crossorigin, scriptAttributes, linkAttributes, requestStack, preloadEnabled) is internal to the test and passed by name.
+- **Placeholder scan:** none — every code step carries complete code; doc steps name exact insertion points and required content.
+```

--- a/docs/superpowers/specs/2026-07-11-twig-asset-tags-design.md
+++ b/docs/superpowers/specs/2026-07-11-twig-asset-tags-design.md
@@ -1,0 +1,213 @@
+# Design: Twig asset tags + ADR 0001 (relative paths + Packages)
+
+Date: 2026-07-11
+Scope: one combined feature spanning the JS plugin (`@symfony/reprise`) and the PHP bundle (`RepriseBundle`).
+Commit scopes (per-task, decided in the plan): `[Entrypoints]` for the JS ADR-0001 slice (`entrypoints.json` relative refs + SRI keying), `[Rsbuild]` for the ESM-output change, `[Twig]` for the PHP renderer + extension + config. One cohesive feature, sliced by the plan.
+
+## Problem
+
+`RepriseBundle` reads `entrypoints.json` (via `EntrypointsLookup`, done) but has **no way to render
+the `<script>`/`<link>` tags** a template needs. This is the keystone that connects the JS build to
+Symfony: `{{ reprise_entry_script_tags('app') }}` in Twig -> the actual tags.
+
+Rendering the tags correctly also means adopting **ADR 0001** (accepted): the bundler emits
+content-hashed files and the PHP side turns a reference into a URL via `symfony/asset` `Packages`
+(`base_path` + `base_urls`), instead of the plugin baking final URLs into `entrypoints.json`. That
+is why this is one feature spanning JS + PHP.
+
+## Scope (one feature, JS + PHP)
+
+Chosen over decomposing into two specs: implement ADR 0001 end to end plus the Twig renderer in a
+single design. The plan will slice it into JS tasks and PHP tasks.
+
+Covered:
+- **A. JS** — `entrypoints.json` (build) emits relative hashed paths; SRI keyed by the reference;
+  both bundlers standardise on ESM output.
+- **B. PHP** — `TagRenderer` + Twig extension with four functions; dev HMR client auto-injection;
+  `modulepreload`; SRI + crossorigin.
+- **C. URL resolution** — via a `framework.assets` package (`reprise.asset_package`).
+- **D. WebLink** — `Link:` headers when `symfony/web-link` is installed.
+
+## Decisions (from brainstorming)
+
+1. Twig API: `reprise_entry_script_tags(entry, package?)`, `reprise_entry_link_tags(entry, package?)`,
+   `reprise_entry_js_files(entry)`, `reprise_entry_css_files(entry)`. `reprise_` prefix, no `encore_` alias.
+2. `type="module"` is the uniform default; both bundlers standardise on ESM output.
+3. Dev HMR: `reprise_entry_script_tags` auto-injects `@vite/client` once per request when in dev.
+4. `preload` chunks -> `<link rel="modulepreload">`; `dynamic` not rendered (runtime).
+5. WebLink integration included (optional dep).
+6. Mono-build (single `entrypoints.json`).
+7. `crossorigin`: `anonymous` automatically when `integrity` is present; otherwise config-driven (default off).
+8. Config path key: `output_path` (a **directory**, Encore- and JS-`outputPath`-consistent); the
+   bundle reads `output_path/entrypoints.json`.
+9. URL resolution via a **`framework.assets` package** named by `reprise.asset_package` (no custom
+   `reprise.assets.base_path/base_urls`).
+
+## A. JS side (entrypoints.json + ESM)
+
+### Relative hashed paths (build)
+
+`buildEntrypoints` (`assets/src/core/format.ts`) currently maps each file to `joinUrl(urlPrefix, fileName)`.
+For **build**, the reference becomes the **docroot-relative path**: `publicPath` with the leading
+slash stripped, joined with the file name -> `build/app-<hash>.js` (no leading slash, no origin).
+For **dev**, references stay **absolute** dev-server-origin URLs (`http://127.0.0.1:5173/build/app.js`),
+unchanged — `Packages` returns absolute URLs as-is.
+
+Concretely: the build `BuildContext.urlPrefix` drops its leading slash (`build/` instead of `/build/`);
+the dev path is untouched.
+
+### CDN reframe
+
+An absolute (CDN) `publicPath` is no longer how CDN works. CDN moves to the PHP side via
+`framework.assets.base_urls` on the Reprise package. `publicPath` (JS) is once again just the local
+path prefix. The docs' "Using a CDN" section is rewritten around `framework.assets`. The JS `cdn`
+integration test and the `publicPath`-with-`://` guard change accordingly (an absolute build
+`publicPath` is no longer the CDN mechanism; keep the guard's behaviour scoped to what still needs it).
+
+### SRI keying
+
+The `integrity` map in `entrypoints.json` is keyed by the **reference** the renderer resolves — the
+relative path in build (`build/app-<hash>.js`), the absolute URL in dev. Today it is keyed by the
+final URL; the change is the key only (SRI hashing of on-disk bytes is unaffected). `getIntegrityData()`
+then answers `map[$reference]`.
+
+### ESM standardisation
+
+Both bundlers emit ESM so `type="module"` is always correct. Vite already does. The **Rsbuild adapter**
+sets Rspack's output to ESM (`output.module` / the Rsbuild equivalent). `entrypoints.json` needs no
+per-entry module flag.
+
+**Risk (verify early):** Rspack ESM output for a web target must load and run correctly (chunk loading,
+browser support). If it turns out unreliable, fall back to decision #2's "config-driven per bundler".
+
+### manifest.json is out of scope
+
+Only `entrypoints.json` changes. `manifest.json` (copied files / images, consumed via `asset()` +
+a manifest version strategy) is a **separate concern**, not this feature. The Reprise package's
+empty version strategy is for **entry references only** (used by `TagRenderer`), not for `asset()`
+image lookups.
+
+## B. PHP tag renderer
+
+### `TagRenderer` (`src/Asset/TagRenderer.php`, final, `@internal`, `ResetInterface`)
+
+Consumes `EntrypointsLookupInterface` and `Symfony\Component\Asset\Packages`. Modelled on
+WebpackEncoreBundle's `TagRenderer`, adapted.
+
+`renderScriptTags(string $entryName, ?string $packageName = null): string`:
+1. **Dev HMR** (once per request): if `getDevServer()` is non-null, prepend
+   `<script type="module" src="{devServer.origin}/@vite/client"></script>`. Guarded by a per-request
+   "client injected" flag (reset via `reset()`).
+2. **modulepreload**: for each `getPreloadFiles($entryName)` reference -> `<link rel="modulepreload" href="{url}">`
+   and register it with WebLink (Part D).
+3. **scripts**: for each `getJavaScriptFiles($entryName)` reference -> `<script type="module" src="{url}"`
+   + `integrity`/`crossorigin` when present + configured `script_attributes` + `></script>`.
+   The entry script references are also registered with WebLink as `preload`.
+
+`renderLinkTags(string $entryName, ?string $packageName = null): string`: for each `getCssFiles($entryName)`
+reference -> `<link rel="stylesheet" href="{url}"` + `integrity`/`crossorigin` + `link_attributes` + `>`;
+also registered with WebLink as `preload`.
+
+`getJsFiles`/`getCssFiles(string $entryName): list<string>`: the resolved URLs, no tags (delegate to
+`getJavaScriptFiles`/`getCssFiles` + URL resolution).
+
+URL resolution helper: `resolveUrl(string $reference, ?string $packageName): string` ->
+`$this->packages->getUrl($reference, $packageName ?? $this->defaultPackage)`. A dev absolute URL is
+returned unchanged by `Packages`.
+
+Integrity/crossorigin: when `getIntegrityData()[$reference]` exists, add `integrity="..."` and
+`crossorigin="anonymous"` (unless `crossorigin` is configured otherwise). No integrity in dev (the
+map is empty there).
+
+Per-request dedup: `EntrypointsLookup` already dedups references across calls in a request; a chunk
+shared by two entries is emitted once. `TagRenderer::reset()` clears the HMR-injected flag;
+`EntrypointsLookup::reset()` clears its dedup. Both are wired through the existing
+`ResetAssetsEventListener`.
+
+### Twig extension (`src/Twig/AssetExtension.php`)
+
+An `AbstractExtension` exposing the four `reprise_entry_*` functions (`is_safe: html` for the tag
+functions), each delegating to `TagRenderer`.
+
+## C. URL resolution & config
+
+Resolution goes through a `framework.assets` package the app configures. Reprise config:
+
+```yaml
+reprise:
+    output_path: '%kernel.project_dir%/public/build'   # directory holding entrypoints.json
+    asset_package: 'reprise'                            # optional; a framework.assets package name
+    strict_mode: true
+    crossorigin: false                                  # false | 'anonymous' | 'use-credentials'
+    script_attributes: { }                              # default attributes on <script>
+    link_attributes: { }                                # default attributes on <link>
+```
+
+The app configures the package under `framework.assets`:
+
+```yaml
+framework:
+    assets:
+        packages:
+            reprise:
+                version: false                          # Reprise files are already content-hashed
+                base_urls: ['https://cdn.example.com']  # optional CDN
+```
+
+**Version caveat (documented):** the Reprise package must have `version: false`. The files are
+already content-hashed; a version strategy would version them again. If `asset_package` is unset,
+`TagRenderer` uses the framework **default** package (`getUrl($ref)`); the docs warn this is safe
+only when the default package has no versioning, otherwise configure a dedicated version-less package.
+
+## D. WebLink integration (optional)
+
+When `symfony/web-link` is installed, `TagRenderer` registers the preloadable references on the
+current request's link provider (`_links` attribute, `GenericLinkProvider`), so
+`AddLinkHeaderListener` emits them as `Link:` HTTP headers:
+- `preload` chunks -> `new Link('modulepreload', $url)`.
+- entry JS/CSS -> `new Link('preload', $url)` with `as=script` / `as=style`.
+
+Graceful no-op when `web-link` or the current request is absent. A `reprise.preload` config toggle
+(default: on when web-link is present) allows disabling it.
+
+## Components / files
+
+- JS: `assets/src/core/format.ts` (relative refs + SRI keying), `assets/src/rsbuild.ts` (ESM output),
+  affected tests (`assets/test/core/format.test.ts`, collectors, `integration/cdn.test.ts`,
+  build/dev integration), `doc/index.rst` (CDN reframe + a new "Rendering asset tags" section — Vite
+  and Rsbuild examples).
+- PHP: `src/Asset/TagRenderer.php`, `src/Twig/AssetExtension.php`, `src/DependencyInjection/Configuration.php`,
+  `src/DependencyInjection/RepriseExtension.php`, `config/services.php` (or the bundle's service wiring),
+  reusing existing `EntrypointsLookup`, `DevServer`, `ResetAssetsEventListener`.
+
+## Non-goals
+
+- Multi-build (`builds:` / `entrypointName`) — mono-build now.
+- `encore_*` Twig aliases.
+- React refresh preamble (only `@vite/client` generic injection; note the `devServer.client` field
+  can carry a variant later).
+- `manifest.json` / `asset()` image resolution.
+- Rendering `dynamic` chunks as tags.
+
+## Testing
+
+- **JS** — `format.ts` build refs are relative (no leading slash), dev refs absolute; SRI keyed by
+  reference; both collectors unaffected; the entrypoints.json shape assertions in the build/dev
+  integration tests updated; the CDN test reframed (no absolute build `publicPath`). Rsbuild ESM
+  output asserted (an entry chunk is an ES module).
+- **PHP unit** (`tests/`) — `TagRenderer`: script/link tag HTML, `type="module"`, integrity +
+  crossorigin when present, dev `@vite/client` injected once, `modulepreload` for preload refs,
+  per-request dedup, `Packages` resolution (relative -> base_path; absolute dev -> unchanged),
+  strict-mode error, WebLink links registered when available.
+- **PHP functional** — boot a kernel with the bundle + a `framework.assets` package + a fixture
+  `entrypoints.json`, render each Twig function, assert the output.
+- **Docs** — a "Rendering asset tags" section with a Vite and an Rsbuild example, and the CDN section
+  reframed around `framework.assets`. Prose via the `natural-writing-editor` agent.
+
+## Open risks
+
+1. **Rspack ESM output** (see Part A) — verify a web build loads/runs as ESM before committing to it.
+2. **Dev absolute URL through `Packages`** — confirm `Packages::getUrl('http://127.0.0.1:5173/build/app.js')`
+   returns it unchanged (it should: absolute URLs bypass base_path/version). A unit test pins this.
+3. **`base_path` double-prefix** — confirm a relative ref `build/app-<hash>.js` through a package with
+   `base_path: /myapp/` yields `/myapp/build/app-<hash>.js` (not `/build/...` or a doubled prefix).

--- a/playground/composer.json
+++ b/playground/composer.json
@@ -28,7 +28,8 @@
         "symfony/ux-map": "^3.2",
         "symfony/ux-leaflet-map": "^3.2",
         "symfony/console": "7.4.*|8.1.*",
-        "symfony/dotenv": "7.4.*|8.1.*"
+        "symfony/dotenv": "7.4.*|8.1.*",
+        "symfony/reprise": "@dev"
     },
     "config": {
         "allow-plugins": {
@@ -52,5 +53,13 @@
             "allow-contrib": true,
             "require": "7.4.*|8.1.*"
         }
-    }
+    },
+    "repositories": [{
+        "name": "reprise",
+        "type": "path",
+        "url": "..",
+        "options": {
+            "symlink": true
+        }
+    }]
 }

--- a/playground/config/bundles.php
+++ b/playground/config/bundles.php
@@ -6,4 +6,5 @@ return [
     Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['all' => true],
     Symfony\UX\StimulusBundle\StimulusBundle::class => ['all' => true],
     Symfony\UX\Map\UXMapBundle::class => ['all' => true],
+    Symfony\Reprise\RepriseBundle::class => ['all' => true],
 ];

--- a/playground/config/reference.php
+++ b/playground/config/reference.php
@@ -790,6 +790,15 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         default_map_id?: scalar|Param|null, // Default: null
  *     },
  * }
+ * @psalm-type RepriseConfig = array{
+ *     output_path?: scalar|Param|null, // Directory where the @symfony/reprise plugin writes entrypoints.json and manifest.json. // Default: "%kernel.project_dir%/public/build"
+ *     strict_mode?: bool|Param, // Throw when the entrypoints.json file or a requested entry is missing. // Default: true
+ *     preload?: bool|Param, // Register rendered assets as WebLink Link: headers (HTTP/2 preload). No-op when symfony/web-link is absent. // Default: true
+ *     asset_package?: scalar|Param|null, // Name of a framework.assets package used to resolve entry URLs (must have no version strategy). Null uses the default package. // Default: null
+ *     crossorigin?: false|"anonymous"|"use-credentials"|Param, // crossorigin attribute added alongside SRI integrity: false, "anonymous", or "use-credentials". // Default: false
+ *     script_attributes?: list<mixed>,
+ *     link_attributes?: list<mixed>,
+ * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
@@ -799,6 +808,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     twig_extra?: TwigExtraConfig,
  *     stimulus?: StimulusConfig,
  *     ux_map?: UxMapConfig,
+ *     reprise?: RepriseConfig,
  *     "when@dev"?: array{
  *         imports?: ImportsConfig,
  *         parameters?: ParametersConfig,
@@ -808,6 +818,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         twig_extra?: TwigExtraConfig,
  *         stimulus?: StimulusConfig,
  *         ux_map?: UxMapConfig,
+ *         reprise?: RepriseConfig,
  *     },
  *     "when@prod"?: array{
  *         imports?: ImportsConfig,
@@ -818,6 +829,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         twig_extra?: TwigExtraConfig,
  *         stimulus?: StimulusConfig,
  *         ux_map?: UxMapConfig,
+ *         reprise?: RepriseConfig,
  *     },
  *     "when@test"?: array{
  *         imports?: ImportsConfig,
@@ -828,6 +840,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         twig_extra?: TwigExtraConfig,
  *         stimulus?: StimulusConfig,
  *         ux_map?: UxMapConfig,
+ *         reprise?: RepriseConfig,
  *     },
  *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
  *         imports?: ImportsConfig,

--- a/playground/package.json
+++ b/playground/package.json
@@ -7,14 +7,15 @@
     "rsbuild:dev": "rsbuild dev",
     "rsbuild:build": "rsbuild build"
   },
-  "devDependencies": {
+  "dependencies": {
     "@hotwired/stimulus": "^3.0.0",
-    "@symfony/reprise": "link:../assets",
+    "@symfony/ux-leaflet-map": "^2.36.2",
+    "leaflet": "^1.9.4"
+  },
+  "devDependencies": {
     "@rsbuild/core": "^2.1.5",
-    "@symfony/stimulus-bridge": "^3.2.0 || ^4.0.0",
-    "@symfony/ux-leaflet-map": "^3.2.0",
-    "leaflet": "^1.9.4",
+    "@symfony/reprise": "link:../assets",
     "vite": "^8.1.3",
-    "vite-plugin-inspect": "^11.1.0"
+    "vite-plugin-inspect": "^12.0.0-beta.3"
   }
 }

--- a/playground/symfony.lock
+++ b/playground/symfony.lock
@@ -44,6 +44,9 @@
             ".editorconfig"
         ]
     },
+    "symfony/reprise": {
+        "version": "dev-feat/twig-asset-tags"
+    },
     "symfony/routing": {
         "version": "7.3",
         "recipe": {

--- a/playground/templates/base.html.twig
+++ b/playground/templates/base.html.twig
@@ -5,16 +5,16 @@
         <title>{% block title %}Welcome!{% endblock %}</title>
         <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text><text y=%221.3em%22 x=%220.2em%22 font-size=%2276%22 fill=%22%23fff%22>sf</text></svg>">
         {% block stylesheets %}
-            <link rel="stylesheet" href="{{ asset('build/static/css/app.90dc3bdd26.css') }}">
+            {{ encore_entry_link_tags('app') }}
+            {{ reprise_entry_link_tags('app') }}
         {% endblock %}
 
         {% block javascripts %}
-            <script src="{{ asset('build/static/js/327.cefc8c56dd.js') }}" type="module"></script>
-            <script src="{{ asset('build/static/js/app.c02f8f4d26.js') }}" type="module"></script>
+            {{ encore_entry_script_tags('app') }}
+            {{ reprise_entry_script_tags('app') }}
         {% endblock %}
     </head>
     <body>
         {% block body %}{% endblock %}
-        <div data-controller="hello"></div>
     </body>
 </html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,31 +59,29 @@ importers:
         version: 4.1.10(@types/node@26.1.0)(jsdom@29.1.1)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0))
 
   playground:
-    devDependencies:
+    dependencies:
       '@hotwired/stimulus':
         specifier: ^3.0.0
         version: 3.2.2
+      '@symfony/ux-leaflet-map':
+        specifier: ^2.36.2
+        version: 2.36.2(@hotwired/stimulus@3.2.2)(leaflet@1.9.4)
+      leaflet:
+        specifier: ^1.9.4
+        version: 1.9.4
+    devDependencies:
       '@rsbuild/core':
         specifier: ^2.1.5
         version: 2.1.5(core-js@3.45.1)
       '@symfony/reprise':
         specifier: link:../assets
         version: link:../assets
-      '@symfony/stimulus-bridge':
-        specifier: ^3.2.0 || ^4.0.0
-        version: 4.0.1(@hotwired/stimulus@3.2.2)
-      '@symfony/ux-leaflet-map':
-        specifier: ^3.2.0
-        version: 3.2.0(@hotwired/stimulus@3.2.2)(leaflet@1.9.4)
-      leaflet:
-        specifier: ^1.9.4
-        version: 1.9.4
       vite:
         specifier: ^8.1.3
         version: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0)
       vite-plugin-inspect:
-        specifier: ^11.1.0
-        version: 11.1.0(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0))
+        specifier: ^12.0.0-beta.3
+        version: 12.0.0-beta.3(@rspack/core@2.1.3(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.1.4)(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0))
 
 packages:
 
@@ -163,11 +161,25 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
+  '@devframes/hub@0.5.4':
+    resolution: {integrity: sha512-NZs5RFuNb6tjQd2JBsRYQT+OqE+z16Kg9/72HG4k+uJdzK90sAGtAjOwK8bsvav/9l85KGx4agfkgxnfbl313w==}
+    peerDependencies:
+      devframe: 0.5.4
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
@@ -337,16 +349,14 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@hotwired/stimulus-webpack-helpers@1.0.1':
-    resolution: {integrity: sha512-wa/zupVG0eWxRYJjC1IiPBdt3Lruv0RqGN+/DTMmUWUyMAEB27KXmVY6a8YpUVTM7QwVuaLNGW4EqDgrS2upXQ==}
-    peerDependencies:
-      '@hotwired/stimulus': '>= 3.0'
-
   '@hotwired/stimulus@3.2.2':
     resolution: {integrity: sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -366,6 +376,136 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@oxc-parser/binding-android-arm-eabi@0.132.0':
+    resolution: {integrity: sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.132.0':
+    resolution: {integrity: sha512-SThDrSeamB/kG2+NxcJ5/wSLcV6dUqDknrPLqFYQ0ST/55mtBP4M7Q/f3QbubH6aAd11wpzZn/nwbVRSdobOpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.132.0':
+    resolution: {integrity: sha512-Lc0f/TYoKBghE5/2Gsv7bLXk+TJZunx2Tf61X8hG4ARXdc8UYI26dCGccFSd1AyFbK3jfaNXtMnupggDbjPXdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.132.0':
+    resolution: {integrity: sha512-RG2eJIpf7C21z9HSSXFw1bTArdpKe7Y4fwcJTwRq1yCSe1vSavaN9GA1sm9KqzemTLAGVktQ+7qBTGp0vQeUZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.132.0':
+    resolution: {integrity: sha512-wQIPntPLtJ8NcBpvKPbEv3NqzV6k8eP8tP/jE9Rg8HTg/j7urZGFSsTCPCW5k77Qfw2DM4vRvc9p3I4yq/Shvw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.132.0':
+    resolution: {integrity: sha512-PixKEpeSe3yxQWqNyOCBALRYc72+Tj7ILDofUl3iXo25cVOzLA6jHUhmOINRtWIPh7dbUie3QNeabwaQpZTw6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.132.0':
+    resolution: {integrity: sha512-sCR+DzGHlyHKnbA2z9zWjTUhIo8Sy0enJl4RDsBwPmkxYynPatpwOAWe8W5127SlW0boqUWHGtr1NWn5UwIhXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.132.0':
+    resolution: {integrity: sha512-sQBix5P2cW+IpzTcCwYxnh9yALrKSIkKJThspBvMGcygSMnbzkSvhN7SfuX1hvBk8y1XEChsdkU3ET0V5DmzUw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.132.0':
+    resolution: {integrity: sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.132.0':
+    resolution: {integrity: sha512-CmX/ulNBOEwWTyVRmcpYKAcAizW6+OjtLJgo7fXoL9OqQvjF4VER8tPomv44vwzfSCy1BHbsB0ZlZYzYJNj4cA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.132.0':
+    resolution: {integrity: sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.132.0':
+    resolution: {integrity: sha512-bLz+Xi+Agnfmd7kWPEsSVwCn2k4EyIalZkNBcQ0OGIv9rqn8VgCPLNd03tM9mKX/5TdlvDXalz0q71BIrOPNqg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.132.0':
+    resolution: {integrity: sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.132.0':
+    resolution: {integrity: sha512-WcEaSNHFk8yz5YFlQQAlhq6jOFmZBB/RKE7uzhyCIf+pF1Lmv9gUH4221mle2Gd9iHyWT3ySNph8yZgb1xYdWg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.132.0':
+    resolution: {integrity: sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.132.0':
+    resolution: {integrity: sha512-FWzmUGrZ6GUby4U7WIwcCtab6tdmlTO3xTRRKyb5kjIJVEiaUAT8animUG/nK8ZCA8gkRkPOTId4rl6uTqUmJQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.132.0':
+    resolution: {integrity: sha512-TlbMppxJI5CjWDes0QaP6G3aneVg1yikBu5QYI+DUShF9WDL66ccgKFNNGmi/Wybtszw6hxwAvv76T4DaPKnHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.132.0':
+    resolution: {integrity: sha512-RH/NbFjGKqdUAUi7Oh3LQPxUk2hsWFEEQ38HSnbRQT8QjBZFKqL1fMbmsB3N4jy/KPh9iX94+9dmkEMBBbambw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.132.0':
+    resolution: {integrity: sha512-JUr4jQY9jxoIB/YTLXr6XofSi5xikj6p5/Ns1h0VOBDT0j1jKU+kMsv2xxv51RwnETcXpA1Yw/9oUAfcqfaqEA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.132.0':
+    resolution: {integrity: sha512-2dapgHpA5X8DSXF4AU36hJWYf6zP0tKjMXFRAZFBD62pkevW/uhFDXoFH9Y/3Fd2EtDrw5ByNnR1wVE9X9y0SQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.132.0':
+    resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
 
   '@oxc-project/types@0.138.0':
     resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
@@ -814,14 +954,8 @@ packages:
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
-  '@symfony/stimulus-bridge@4.0.1':
-    resolution: {integrity: sha512-+/kSQ4qFXMbZS+HjkhzOxwdN+60pMev7kzzDpQV/Tdm/iIWoxx5GDsVcdLaBb2783BVQHyrBP72JerF2SXTbTg==}
-    engines: {node: ^18.12.0 || ^20.0.0 || >=22.0}
-    peerDependencies:
-      '@hotwired/stimulus': ^3.0
-
-  '@symfony/ux-leaflet-map@3.2.0':
-    resolution: {integrity: sha512-hZNJoNok45N+mVa5Ql6Uj0T3wqb+dd7wAi7/eqJH8N9b8KOxALWBu2pNubqDGT9yM9emp8uPO22NQ6P5+qPwig==}
+  '@symfony/ux-leaflet-map@2.36.2':
+    resolution: {integrity: sha512-n7yaBpRMY9scanUYGXL+jRjbeGtCepWhz0gYHfl6v7QuVofyllRzGp4vlBFS+BsWF/JqABwInOAkzS+d0RhtGg==}
     peerDependencies:
       '@hotwired/stimulus': ^3.0.0
       leaflet: ^1.9.4
@@ -844,14 +978,18 @@ packages:
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
-  '@types/json-schema@7.0.15':
-    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-
   '@types/node@26.1.0':
     resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
 
-  '@types/webpack-env@1.18.8':
-    resolution: {integrity: sha512-G9eAoJRMLjcvN4I08wB5I7YofOb/kaJNd5uoCMX+LbKXTPCF+ZIHuqTnFaK9Jz1rgs035f9JUPUhNFtqgucy/A==}
+  '@valibot/to-json-schema@1.7.1':
+    resolution: {integrity: sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==}
+    peerDependencies:
+      valibot: ^1.4.0
+
+  '@vitejs/devtools-kit@0.3.4':
+    resolution: {integrity: sha512-QHvb3wF0KZxvbfEplzzdGenB/dWoPBQlUnw3VVBm5qUYTdoud8rOoem9QI6h/+7a+iwy88LmLigxbSXbbv2Uyg==}
+    peerDependencies:
+      vite: '*'
 
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
@@ -887,26 +1025,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ajv-formats@2.1.1:
-    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
-  ajv-keywords@5.1.0:
-    resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
-    peerDependencies:
-      ajv: ^8.8.2
-
-  ajv@8.20.0:
-    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
-
-  ansis@3.17.0:
-    resolution: {integrity: sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==}
-    engines: {node: '>=14'}
-
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
@@ -933,9 +1051,6 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
-
-  birpc@2.3.0:
-    resolution: {integrity: sha512-ijbtkn/F3Pvzb6jHypHRyve2QApOCZDR25D/VnkY2G/lBNcXCTsnsCxgY4k4PkVB7zfwzYbY3O9Lcqe3xufS5g==}
 
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
@@ -970,6 +1085,9 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -983,15 +1101,6 @@ packages:
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  debug@4.4.1:
-    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1009,8 +1118,8 @@ packages:
     resolution: {integrity: sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==}
     engines: {node: '>=18'}
 
-  default-browser@5.2.1:
-    resolution: {integrity: sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==}
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
     engines: {node: '>=18'}
 
   define-lazy-prop@3.0.0:
@@ -1023,6 +1132,14 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devframe@0.5.4:
+    resolution: {integrity: sha512-dbHU/LuptR1aMXcizjHUeY3gu7qVaRQoFYqbbyyGuO6Y+avFA4uQtwinHtG1qa7lRel/7b8JrBDm0nbnxU3vqg==}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.0.0
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
 
   dts-resolver@3.0.0:
     resolution: {integrity: sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q==}
@@ -1059,12 +1176,6 @@ packages:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
-  fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
-
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1090,6 +1201,16 @@ packages:
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
+
+  h3@2.0.1-rc.22:
+    resolution: {integrity: sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==}
+    engines: {node: '>=20.11.1'}
+    hasBin: true
+    peerDependencies:
+      crossws: ^0.4.1
+    peerDependenciesMeta:
+      crossws:
+        optional: true
 
   has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
@@ -1126,6 +1247,10 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
+
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
@@ -1159,9 +1284,6 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
-
-  json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   leaflet@1.9.4:
     resolution: {integrity: sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==}
@@ -1240,10 +1362,6 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
-  loader-utils@3.3.1:
-    resolution: {integrity: sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==}
-    engines: {node: '>= 12.13.0'}
-
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
@@ -1257,6 +1375,9 @@ packages:
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -1279,6 +1400,12 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  nostics@0.2.0:
+    resolution: {integrity: sha512-/WQpI46UMbqvy1okYb+V+9wW3J8/m6GJ33wm691n/tyi6YtJiZ6ssJjENAU7y4evfYrrgYN9HllKDzPvffil1w==}
+
+  nostics@1.1.4:
+    resolution: {integrity: sha512-U4FApICSLCQ0dYiN59pxUCEZC053palQXi57yLaNdMaL6TBY4C4q3qZrJKUGcor2dGv8EhEwt8y5KvU2bo2kFg==}
+
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
@@ -1286,9 +1413,13 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
-  open@10.1.2:
-    resolution: {integrity: sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==}
-    engines: {node: '>=18'}
+  open@11.0.0:
+    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+    engines: {node: '>=20'}
+
+  oxc-parser@0.132.0:
+    resolution: {integrity: sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   oxfmt@0.58.0:
     resolution: {integrity: sha512-8feG/7NVEHDVwc1OUpP6Pks+TnaDFUw2jLLFIMi5bcmmwxAX2wBQvjSzj62RRTYBf2Op1Wt8xbkmagmPTR5ETg==}
@@ -1322,8 +1453,8 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  perfect-debounce@1.0.0:
-    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+  perfect-debounce@2.1.0:
+    resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1336,9 +1467,16 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
 
   pstree.remy@1.1.8:
     resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
@@ -1385,6 +1523,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rou3@0.8.1:
+    resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
+
   run-applescript@7.0.0:
     resolution: {integrity: sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==}
     engines: {node: '>=18'}
@@ -1392,10 +1533,6 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
-
-  schema-utils@4.3.3:
-    resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
-    engines: {node: '>= 10.13.0'}
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
@@ -1409,8 +1546,8 @@ packages:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
 
-  sirv@3.0.1:
-    resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
   source-map-js@1.2.1:
@@ -1423,6 +1560,11 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  srvx@0.11.21:
+    resolution: {integrity: sha512-GWTHjKMeekX8CwJf4VU9Oo6mJpSGaflGMddbCvR+Cmmh9sslRMiGbAoqqZacE0r1ncARh6buCEETr2W52F8b1w==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -1539,6 +1681,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
@@ -1552,30 +1697,61 @@ packages:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
-  unplugin-utils@0.2.4:
-    resolution: {integrity: sha512-8U/MtpkPkkk3Atewj1+RcKIjb5WBimZ/WSLhhR3w6SsIj8XJuKTacSP8g+2JhfSGw0Cb125Y+2zA/IzJZDVbhA==}
-    engines: {node: '>=18.12.0'}
+  unplugin-utils@0.3.2:
+    resolution: {integrity: sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==}
+    engines: {node: '>=20.19.0'}
 
   unplugin@2.3.4:
     resolution: {integrity: sha512-m4PjxTurwpWfpMomp8AptjD5yj8qEZN5uQjjGM3TAs9MWWD2tXSSNNj6jGR2FoVGod4293ytyV6SwBbertfyJg==}
     engines: {node: '>=18.12.0'}
 
-  vite-dev-rpc@1.0.7:
-    resolution: {integrity: sha512-FxSTEofDbUi2XXujCA+hdzCDkXFG1PXktMjSk1efq9Qb5lOYaaM9zNSvKvPPF7645Bak79kSp1PTooMW2wktcA==}
+  unplugin@3.3.0:
+    resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.1
+      '@farmfe/core': '*'
+      '@rspack/core': '*'
+      bun-types-no-globals: '*'
+      esbuild: '*'
+      rolldown: '*'
+      rollup: '*'
+      unloader: '*'
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      '@farmfe/core':
+        optional: true
+      '@rspack/core':
+        optional: true
+      bun-types-no-globals:
+        optional: true
+      esbuild:
+        optional: true
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      unloader:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
 
-  vite-hot-client@2.0.4:
-    resolution: {integrity: sha512-W9LOGAyGMrbGArYJN4LBCdOC5+Zwh7dHvOHC0KmGKkJhsOzaKbpo/jEjpPKVHIW0/jBWj8RZG0NUxfgA8BxgAg==}
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
     peerDependencies:
-      vite: ^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  vite-plugin-inspect@11.1.0:
-    resolution: {integrity: sha512-r3Nx8xGQ08bSoNu7gJGfP5H/wNOROHtv0z3tWspplyHZJlABwNoPOdFEmcVh+lVMDyk/Be4yt8oS596ZHoYhOg==}
+  vite-plugin-inspect@12.0.0-beta.3:
+    resolution: {integrity: sha512-1uMZPSO7Y09KGRhBIhdxdobot14VxKrxm/yYxs5h5FqI4UplbP8PADazLveAUiQSvNwyl9taGPMBfgktX5g8Gg==}
     engines: {node: '>=14'}
     peerDependencies:
       '@nuxt/kit': '*'
-      vite: ^6.0.0
+      vite: ^8.0.0-0
     peerDependenciesMeta:
       '@nuxt/kit':
         optional: true
@@ -1688,6 +1864,22 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  wsl-utils@0.3.1:
+    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
+    engines: {node: '>=20'}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -1772,13 +1964,48 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
+  '@devframes/hub@0.5.4(@rspack/core@2.1.3(@swc/helpers@0.5.23))(devframe@0.5.4(@rspack/core@2.1.3(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.1.4)(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0)))(esbuild@0.28.1)(rolldown@1.1.4)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0))':
+    dependencies:
+      birpc: 4.0.0
+      devframe: 0.5.4(@rspack/core@2.1.3(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.1.4)(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0))
+      nostics: 0.2.0(@rspack/core@2.1.3(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.1.4)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0))
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      tinyexec: 1.2.4
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - vite
+      - webpack
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -1868,15 +2095,16 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
-  '@hotwired/stimulus-webpack-helpers@1.0.1(@hotwired/stimulus@3.2.2)':
-    dependencies:
-      '@hotwired/stimulus': 3.2.2
-
   '@hotwired/stimulus@3.2.2': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -1894,12 +2122,85 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
+
+  '@oxc-parser/binding-android-arm-eabi@0.132.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.132.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.132.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.132.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.132.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.132.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.132.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.132.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.132.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.132.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.132.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.132.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.132.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.132.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.132.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.132.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.132.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.132.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.132.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.132.0':
+    optional: true
+
+  '@oxc-project/types@0.132.0': {}
 
   '@oxc-project/types@0.138.0': {}
 
@@ -2150,15 +2451,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@symfony/stimulus-bridge@4.0.1(@hotwired/stimulus@3.2.2)':
-    dependencies:
-      '@hotwired/stimulus': 3.2.2
-      '@hotwired/stimulus-webpack-helpers': 1.0.1(@hotwired/stimulus@3.2.2)
-      '@types/webpack-env': 1.18.8
-      loader-utils: 3.3.1
-      schema-utils: 4.3.3
-
-  '@symfony/ux-leaflet-map@3.2.0(@hotwired/stimulus@3.2.2)(leaflet@1.9.4)':
+  '@symfony/ux-leaflet-map@2.36.2(@hotwired/stimulus@3.2.2)(leaflet@1.9.4)':
     dependencies:
       '@hotwired/stimulus': 3.2.2
       leaflet: 1.9.4
@@ -2181,13 +2474,39 @@ snapshots:
 
   '@types/jsesc@2.5.1': {}
 
-  '@types/json-schema@7.0.15': {}
-
   '@types/node@26.1.0':
     dependencies:
       undici-types: 8.3.0
 
-  '@types/webpack-env@1.18.8': {}
+  '@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3))':
+    dependencies:
+      valibot: 1.4.2(typescript@6.0.3)
+
+  '@vitejs/devtools-kit@0.3.4(@rspack/core@2.1.3(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.1.4)(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0))':
+    dependencies:
+      '@devframes/hub': 0.5.4(@rspack/core@2.1.3(@swc/helpers@0.5.23))(devframe@0.5.4(@rspack/core@2.1.3(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.1.4)(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0)))(esbuild@0.28.1)(rolldown@1.1.4)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0))
+      birpc: 4.0.0
+      devframe: 0.5.4(@rspack/core@2.1.3(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.1.4)(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0))
+      mlly: 1.8.2
+      nostics: 1.1.4
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      tinyexec: 1.2.4
+      vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@modelcontextprotocol/sdk'
+      - '@rspack/core'
+      - bufferutil
+      - bun-types-no-globals
+      - crossws
+      - esbuild
+      - rolldown
+      - rollup
+      - typescript
+      - unloader
+      - utf-8-validate
+      - webpack
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -2232,24 +2551,6 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  ajv-formats@2.1.1(ajv@8.20.0):
-    optionalDependencies:
-      ajv: 8.20.0
-
-  ajv-keywords@5.1.0(ajv@8.20.0):
-    dependencies:
-      ajv: 8.20.0
-      fast-deep-equal: 3.1.3
-
-  ajv@8.20.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-
-  ansis@3.17.0: {}
-
   ansis@4.3.1: {}
 
   anymatch@3.1.3:
@@ -2272,8 +2573,6 @@ snapshots:
       require-from-string: 2.0.2
 
   binary-extensions@2.3.0: {}
-
-  birpc@2.3.0: {}
 
   birpc@4.0.0: {}
 
@@ -2311,6 +2610,8 @@ snapshots:
   commander@2.20.3:
     optional: true
 
+  confbox@0.1.8: {}
+
   convert-source-map@2.0.0: {}
 
   core-js@3.45.1:
@@ -2328,10 +2629,6 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
-  debug@4.4.1:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.3(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -2342,7 +2639,7 @@ snapshots:
 
   default-browser-id@5.0.0: {}
 
-  default-browser@5.2.1:
+  default-browser@5.5.0:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.0
@@ -2352,6 +2649,32 @@ snapshots:
   defu@6.1.7: {}
 
   detect-libc@2.1.2: {}
+
+  devframe@0.5.4(@rspack/core@2.1.3(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.1.4)(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0)):
+    dependencies:
+      '@valibot/to-json-schema': 1.7.1(valibot@1.4.2(typescript@6.0.3))
+      birpc: 4.0.0
+      cac: 7.0.0
+      h3: 2.0.1-rc.22
+      mrmime: 2.0.1
+      nostics: 0.2.0(@rspack/core@2.1.3(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.1.4)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0))
+      pathe: 2.0.3
+      valibot: 1.4.2(typescript@6.0.3)
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bufferutil
+      - bun-types-no-globals
+      - crossws
+      - esbuild
+      - rolldown
+      - rollup
+      - typescript
+      - unloader
+      - utf-8-validate
+      - vite
+      - webpack
 
   dts-resolver@3.0.0: {}
 
@@ -2398,10 +2721,6 @@ snapshots:
 
   expect-type@1.4.0: {}
 
-  fast-deep-equal@3.1.3: {}
-
-  fast-uri@3.1.3: {}
-
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -2420,6 +2739,11 @@ snapshots:
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
+
+  h3@2.0.1-rc.22:
+    dependencies:
+      rou3: 0.8.1
+      srvx: 0.11.21
 
   has-flag@3.0.0: {}
 
@@ -2446,6 +2770,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-in-ssh@1.0.0: {}
 
   is-inside-container@1.0.0:
     dependencies:
@@ -2489,8 +2815,6 @@ snapshots:
       - '@noble/hashes'
 
   jsesc@3.1.0: {}
-
-  json-schema-traverse@1.0.0: {}
 
   leaflet@1.9.4: {}
 
@@ -2543,8 +2867,6 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  loader-utils@3.3.1: {}
-
   lru-cache@11.5.1: {}
 
   magic-string@0.30.21:
@@ -2556,6 +2878,13 @@ snapshots:
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.7
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.17.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
 
   mrmime@2.0.1: {}
 
@@ -2578,16 +2907,61 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  nostics@0.2.0(@rspack/core@2.1.3(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.1.4)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0)):
+    dependencies:
+      magic-string: 0.30.21
+      oxc-parser: 0.132.0
+      unplugin: 3.3.0(@rspack/core@2.1.3(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.1.4)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - vite
+      - webpack
+
+  nostics@1.1.4: {}
+
   obug@2.1.3: {}
 
   ohash@2.0.11: {}
 
-  open@10.1.2:
+  open@11.0.0:
     dependencies:
-      default-browser: 5.2.1
+      default-browser: 5.5.0
       define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
       is-inside-container: 1.0.0
-      is-wsl: 3.1.0
+      powershell-utils: 0.1.0
+      wsl-utils: 0.3.1
+
+  oxc-parser@0.132.0:
+    dependencies:
+      '@oxc-project/types': 0.132.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.132.0
+      '@oxc-parser/binding-android-arm64': 0.132.0
+      '@oxc-parser/binding-darwin-arm64': 0.132.0
+      '@oxc-parser/binding-darwin-x64': 0.132.0
+      '@oxc-parser/binding-freebsd-x64': 0.132.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.132.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.132.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.132.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.132.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.132.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.132.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.132.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.132.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.132.0
+      '@oxc-parser/binding-linux-x64-musl': 0.132.0
+      '@oxc-parser/binding-openharmony-arm64': 0.132.0
+      '@oxc-parser/binding-wasm32-wasi': 0.132.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.132.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.132.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.132.0
 
   oxfmt@0.58.0:
     dependencies:
@@ -2641,7 +3015,7 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  perfect-debounce@1.0.0: {}
+  perfect-debounce@2.1.0: {}
 
   picocolors@1.1.1: {}
 
@@ -2649,11 +3023,19 @@ snapshots:
 
   picomatch@4.0.5: {}
 
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
   postcss@8.5.16:
     dependencies:
       nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  powershell-utils@0.1.0: {}
 
   pstree.remy@1.1.8: {}
 
@@ -2706,18 +3088,13 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.4
       '@rolldown/binding-win32-x64-msvc': 1.1.4
 
+  rou3@0.8.1: {}
+
   run-applescript@7.0.0: {}
 
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
-
-  schema-utils@4.3.3:
-    dependencies:
-      '@types/json-schema': 7.0.15
-      ajv: 8.20.0
-      ajv-formats: 2.1.1(ajv@8.20.0)
-      ajv-keywords: 5.1.0(ajv@8.20.0)
 
   semver@7.8.5: {}
 
@@ -2727,7 +3104,7 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  sirv@3.0.1:
+  sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
@@ -2743,6 +3120,8 @@ snapshots:
 
   source-map@0.6.1:
     optional: true
+
+  srvx@0.11.21: {}
 
   stackback@0.0.2: {}
 
@@ -2835,6 +3214,8 @@ snapshots:
 
   typescript@6.0.3: {}
 
+  ufo@1.6.4: {}
+
   unconfig-core@7.5.0:
     dependencies:
       '@quansync/fs': 1.0.0
@@ -2846,7 +3227,7 @@ snapshots:
 
   undici@7.28.0: {}
 
-  unplugin-utils@0.2.4:
+  unplugin-utils@0.3.2:
     dependencies:
       pathe: 2.0.3
       picomatch: 4.0.5
@@ -2857,30 +3238,47 @@ snapshots:
       picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
 
-  vite-dev-rpc@1.0.7(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0)):
+  unplugin@3.3.0(@rspack/core@2.1.3(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.1.4)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
-      birpc: 2.3.0
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.5
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      '@rspack/core': 2.1.3(@swc/helpers@0.5.23)
+      esbuild: 0.28.1
+      rolldown: 1.1.4
       vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0)
-      vite-hot-client: 2.0.4(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0))
 
-  vite-hot-client@2.0.4(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0)):
-    dependencies:
-      vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0)
+  valibot@1.4.2(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
 
-  vite-plugin-inspect@11.1.0(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0)):
+  vite-plugin-inspect@12.0.0-beta.3(@rspack/core@2.1.3(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.1.4)(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
-      ansis: 3.17.0
-      debug: 4.4.1
+      '@vitejs/devtools-kit': 0.3.4(@rspack/core@2.1.3(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.1.4)(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0))
+      ansis: 4.3.1
       error-stack-parser-es: 1.0.5
+      obug: 2.1.3
       ohash: 2.0.11
-      open: 10.1.2
-      perfect-debounce: 1.0.0
-      sirv: 3.0.1
-      unplugin-utils: 0.2.4
+      open: 11.0.0
+      perfect-debounce: 2.1.0
+      sirv: 3.0.2
+      unplugin-utils: 0.3.2
       vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0)
-      vite-dev-rpc: 1.0.7(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0))
     transitivePeerDependencies:
-      - supports-color
+      - '@farmfe/core'
+      - '@modelcontextprotocol/sdk'
+      - '@rspack/core'
+      - bufferutil
+      - bun-types-no-globals
+      - crossws
+      - esbuild
+      - rolldown
+      - rollup
+      - typescript
+      - unloader
+      - utf-8-validate
+      - webpack
 
   vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.39.2)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
@@ -2948,6 +3346,13 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  ws@8.21.0: {}
+
+  wsl-utils@0.3.1:
+    dependencies:
+      is-wsl: 3.1.0
+      powershell-utils: 0.1.0
 
   xml-name-validator@5.0.0: {}
 

--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Asset;
+
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\WebLink\GenericLinkProvider;
+use Symfony\Component\WebLink\Link;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * Renders the <script>/<link> tags for an entry, resolving each entrypoints.json reference through
+ * Symfony's asset Packages (ADR 0001) and adding SRI integrity/crossorigin when present.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class TagRenderer implements ResetInterface
+{
+    private bool $clientInjected = false;
+
+    /**
+     * @param array<string, bool|string> $scriptAttributes
+     * @param array<string, bool|string> $linkAttributes
+     */
+    public function __construct(
+        private readonly EntrypointsLookupInterface $lookup,
+        private readonly Packages $packages,
+        private readonly ?RequestStack $requestStack = null,
+        private readonly ?string $defaultPackage = null,
+        private readonly string|false $crossorigin = false,
+        private readonly bool $preload = true,
+        private readonly array $scriptAttributes = [],
+        private readonly array $linkAttributes = [],
+    ) {
+    }
+
+    public function renderScriptTags(string $entryName, ?string $packageName = null): string
+    {
+        $integrity = $this->lookup->getIntegrityData();
+        $tags = [];
+
+        $devServer = $this->lookup->getDevServer();
+        if (!$this->clientInjected && null !== $devServer && null !== $devServer->client) {
+            $tags[] = \sprintf('<script type="module" src="%s"></script>', htmlspecialchars($devServer->client, \ENT_QUOTES));
+            $this->clientInjected = true;
+        }
+
+        foreach ($this->lookup->getPreloadFiles($entryName) as $reference) {
+            $url = $this->url($reference, $packageName);
+            $attributes = ['rel' => 'modulepreload', 'href' => $url];
+            $this->applyIntegrity($attributes, $reference, $integrity);
+            $tags[] = \sprintf('<link %s>', $this->attributes($attributes));
+            $this->preload($url, 'modulepreload');
+        }
+
+        foreach ($this->lookup->getJavaScriptFiles($entryName) as $reference) {
+            $url = $this->url($reference, $packageName);
+            $attributes = ['src' => $url, 'type' => 'module'];
+            $attributes += $this->scriptAttributes;
+            $this->applyIntegrity($attributes, $reference, $integrity);
+            $tags[] = \sprintf('<script %s></script>', $this->attributes($attributes));
+            $this->preload($url, 'preload', 'script');
+        }
+
+        return implode('', $tags);
+    }
+
+    public function renderLinkTags(string $entryName, ?string $packageName = null): string
+    {
+        $integrity = $this->lookup->getIntegrityData();
+        $tags = [];
+        foreach ($this->lookup->getCssFiles($entryName) as $reference) {
+            $url = $this->url($reference, $packageName);
+            $attributes = ['rel' => 'stylesheet', 'href' => $url];
+            $attributes += $this->linkAttributes;
+            $this->applyIntegrity($attributes, $reference, $integrity);
+            $tags[] = \sprintf('<link %s>', $this->attributes($attributes));
+            $this->preload($url, 'preload', 'style');
+        }
+
+        return implode('', $tags);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getJsFiles(string $entryName, ?string $packageName = null): array
+    {
+        return array_map(fn (string $r) => $this->url($r, $packageName), $this->lookup->getJavaScriptFiles($entryName));
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getCssFiles(string $entryName, ?string $packageName = null): array
+    {
+        return array_map(fn (string $r) => $this->url($r, $packageName), $this->lookup->getCssFiles($entryName));
+    }
+
+    public function reset(): void
+    {
+        $this->clientInjected = false;
+    }
+
+    private function url(string $reference, ?string $packageName): string
+    {
+        return $this->packages->getUrl($reference, $packageName ?? $this->defaultPackage);
+    }
+
+    private function preload(string $url, string $rel, ?string $as = null): void
+    {
+        if (!$this->preload || null === $this->requestStack || !class_exists(GenericLinkProvider::class)) {
+            return;
+        }
+
+        $request = $this->requestStack->getCurrentRequest();
+        if (null === $request) {
+            return;
+        }
+
+        $link = new Link($rel, $url);
+        if (null !== $as) {
+            $link = $link->withAttribute('as', $as);
+        }
+
+        $linkProvider = $request->attributes->get('_links');
+        if (!$linkProvider instanceof GenericLinkProvider) {
+            $linkProvider = new GenericLinkProvider();
+        }
+        $request->attributes->set('_links', $linkProvider->withLink($link));
+    }
+
+    /**
+     * @param array<string, bool|string> $attributes
+     * @param array<string, string>      $integrity
+     */
+    private function applyIntegrity(array &$attributes, string $reference, array $integrity): void
+    {
+        if (!isset($integrity[$reference])) {
+            return;
+        }
+        $attributes['integrity'] = $integrity[$reference];
+        $attributes['crossorigin'] = false === $this->crossorigin ? 'anonymous' : $this->crossorigin;
+    }
+
+    /**
+     * @param array<string, bool|string> $attributes
+     */
+    private function attributes(array $attributes): string
+    {
+        $attributes = array_filter($attributes, static fn (bool|string $v) => false !== $v);
+
+        return implode(' ', array_map(
+            static fn (string $k, bool|string $v) => true === $v ? $k : \sprintf('%s="%s"', $k, htmlspecialchars($v, \ENT_QUOTES)),
+            array_keys($attributes),
+            $attributes,
+        ));
+    }
+}

--- a/src/RepriseBundle.php
+++ b/src/RepriseBundle.php
@@ -17,7 +17,10 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
 use Symfony\Reprise\Asset\EntrypointsLookup;
 use Symfony\Reprise\Asset\EntrypointsLookupInterface;
+use Symfony\Reprise\Asset\TagRenderer;
 use Symfony\Reprise\EventListener\ResetAssetsEventListener;
+use Symfony\Reprise\Twig\AssetExtension;
+use Symfony\Reprise\Twig\AssetRuntime;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
@@ -38,12 +41,33 @@ final class RepriseBundle extends AbstractBundle
                     ->defaultTrue()
                     ->info('Throw when the entrypoints.json file or a requested entry is missing.')
                 ->end()
+                ->booleanNode('preload')
+                    ->defaultTrue()
+                    ->info('Register rendered assets as WebLink Link: headers (HTTP/2 preload). No-op when symfony/web-link is absent.')
+                ->end()
+                ->scalarNode('asset_package')
+                    ->defaultNull()
+                    ->info('Name of a framework.assets package used to resolve entry URLs (must have no version strategy). Null uses the default package.')
+                ->end()
+                ->enumNode('crossorigin')
+                    ->values([false, 'anonymous', 'use-credentials'])
+                    ->defaultFalse()
+                    ->info('crossorigin attribute added alongside SRI integrity: false, "anonymous", or "use-credentials".')
+                ->end()
+                ->arrayNode('script_attributes')
+                    ->normalizeKeys(false)->variablePrototype()->end()->defaultValue([])
+                    ->info('Default attributes added to every <script> tag.')
+                ->end()
+                ->arrayNode('link_attributes')
+                    ->normalizeKeys(false)->variablePrototype()->end()->defaultValue([])
+                    ->info('Default attributes added to every <link> tag.')
+                ->end()
             ->end()
         ;
     }
 
     /**
-     * @param array{output_path: string, strict_mode: bool} $config
+     * @param array{output_path: string, strict_mode: bool, preload: bool, asset_package: ?string, crossorigin: string|false, script_attributes: array<string, bool|string>, link_attributes: array<string, bool|string>} $config
      */
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
@@ -62,6 +86,29 @@ final class RepriseBundle extends AbstractBundle
         $services->set('reprise.reset_assets_listener', ResetAssetsEventListener::class)
             ->args([service('reprise.entrypoints_lookup')])
             ->tag('kernel.event_subscriber')
+        ;
+
+        $services->set('reprise.tag_renderer', TagRenderer::class)
+            ->args([
+                service('reprise.entrypoints_lookup'),
+                service('assets.packages'),
+                service('request_stack'),
+                $config['asset_package'],
+                $config['crossorigin'],
+                $config['preload'],
+                $config['script_attributes'],
+                $config['link_attributes'],
+            ])
+            ->tag('kernel.reset', ['method' => 'reset'])
+        ;
+
+        $services->set('reprise.asset_runtime', AssetRuntime::class)
+            ->args([service('reprise.tag_renderer')])
+            ->tag('twig.runtime')
+        ;
+
+        $services->set('reprise.twig_extension', AssetExtension::class)
+            ->tag('twig.extension')
         ;
     }
 }

--- a/src/Twig/AssetExtension.php
+++ b/src/Twig/AssetExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Declares the reprise_entry_* Twig functions, each delegating to the lazily-loaded AssetRuntime so
+ * the TagRenderer is built only when a template actually renders Reprise tags.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class AssetExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('reprise_entry_script_tags', [AssetRuntime::class, 'renderScriptTags'], ['is_safe' => ['html']]),
+            new TwigFunction('reprise_entry_link_tags', [AssetRuntime::class, 'renderLinkTags'], ['is_safe' => ['html']]),
+            new TwigFunction('reprise_entry_js_files', [AssetRuntime::class, 'getJsFiles']),
+            new TwigFunction('reprise_entry_css_files', [AssetRuntime::class, 'getCssFiles']),
+        ];
+    }
+}

--- a/src/Twig/AssetRuntime.php
+++ b/src/Twig/AssetRuntime.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Twig;
+
+use Symfony\Reprise\Asset\TagRenderer;
+use Twig\Extension\RuntimeExtensionInterface;
+
+/**
+ * Lazily-instantiated runtime backing the reprise_entry_* Twig functions.
+ *
+ * Twig instantiates every registered extension as soon as it boots, but a runtime is built only when
+ * one of its functions is actually called. Holding the TagRenderer here (rather than on the
+ * extension) keeps templates that never render Reprise tags from constructing it and its
+ * dependencies (entrypoints lookup, asset packages, request stack).
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class AssetRuntime implements RuntimeExtensionInterface
+{
+    public function __construct(private readonly TagRenderer $tagRenderer)
+    {
+    }
+
+    public function renderScriptTags(string $entryName, ?string $packageName = null): string
+    {
+        return $this->tagRenderer->renderScriptTags($entryName, $packageName);
+    }
+
+    public function renderLinkTags(string $entryName, ?string $packageName = null): string
+    {
+        return $this->tagRenderer->renderLinkTags($entryName, $packageName);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getJsFiles(string $entryName, ?string $packageName = null): array
+    {
+        return $this->tagRenderer->getJsFiles($entryName, $packageName);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getCssFiles(string $entryName, ?string $packageName = null): array
+    {
+        return $this->tagRenderer->getCssFiles($entryName, $packageName);
+    }
+}

--- a/tests/Asset/EntrypointsLookupTest.php
+++ b/tests/Asset/EntrypointsLookupTest.php
@@ -28,10 +28,10 @@ final class EntrypointsLookupTest extends TestCase
     {
         $lookup = $this->lookup();
 
-        $this->assertSame(['/build/app-a1b2.js'], $lookup->getJavaScriptFiles('app'));
-        $this->assertSame(['/build/app-c3d4.css'], $lookup->getCssFiles('app'));
-        $this->assertSame(['/build/shared-e5f6.js'], $lookup->getPreloadFiles('app'));
-        $this->assertSame(['/build/lazy-x.js'], $lookup->getDynamicFiles('app'));
+        $this->assertSame(['build/app-a1b2.js'], $lookup->getJavaScriptFiles('app'));
+        $this->assertSame(['build/app-c3d4.css'], $lookup->getCssFiles('app'));
+        $this->assertSame(['build/shared-e5f6.js'], $lookup->getPreloadFiles('app'));
+        $this->assertSame(['build/lazy-x.js'], $lookup->getDynamicFiles('app'));
     }
 
     public function testDeduplicatesSharedFilesAcrossCalls()
@@ -39,10 +39,10 @@ final class EntrypointsLookupTest extends TestCase
         $lookup = $this->lookup();
 
         // app pulls the shared preload chunk...
-        $this->assertSame(['/build/shared-e5f6.js'], $lookup->getPreloadFiles('app'));
+        $this->assertSame(['build/shared-e5f6.js'], $lookup->getPreloadFiles('app'));
         // ...admin references the same chunk, but it must not be emitted twice on one page.
         $this->assertSame([], $lookup->getPreloadFiles('admin'));
-        $this->assertSame(['/build/admin-99.js'], $lookup->getJavaScriptFiles('admin'));
+        $this->assertSame(['build/admin-99.js'], $lookup->getJavaScriptFiles('admin'));
     }
 
     public function testResetClearsDeduplicationState()
@@ -52,7 +52,7 @@ final class EntrypointsLookupTest extends TestCase
         $lookup->getPreloadFiles('app');
         $lookup->reset();
 
-        $this->assertSame(['/build/shared-e5f6.js'], $lookup->getPreloadFiles('admin'));
+        $this->assertSame(['build/shared-e5f6.js'], $lookup->getPreloadFiles('admin'));
     }
 
     public function testEntryExists()
@@ -69,7 +69,7 @@ final class EntrypointsLookupTest extends TestCase
 
         $this->assertTrue($lookup->isProd());
         $this->assertNull($lookup->getDevServer());
-        $this->assertSame('sha384-app', $lookup->getIntegrityData()['/build/app-a1b2.js']);
+        $this->assertSame('sha384-app', $lookup->getIntegrityData()['build/app-a1b2.js']);
     }
 
     public function testExposesTheDevServerAndDevModeForAServeFlavouredFile()
@@ -83,7 +83,7 @@ final class EntrypointsLookupTest extends TestCase
         $devServer = $lookup->getDevServer();
         $this->assertNotNull($devServer);
         $this->assertSame('http://127.0.0.1:5173', $devServer->origin);
-        $this->assertSame('vite', $devServer->client);
+        $this->assertSame('http://127.0.0.1:5173/build/@vite/client', $devServer->client);
     }
 
     public function testThrowsWhenTheFileIsNotAJsonObject()

--- a/tests/Asset/EntrypointsTest.php
+++ b/tests/Asset/EntrypointsTest.php
@@ -51,7 +51,7 @@ final class EntrypointsTest extends TestCase
     {
         $devServer = Entrypoints::fromArray([
             'isProd' => false,
-            'devServer' => ['origin' => 'http://localhost:5173', 'client' => 'vite'],
+            'devServer' => ['origin' => 'http://localhost:5173', 'client' => 'http://localhost:5173/build/@vite/client'],
             'publicPath' => '/build/',
             'entryPoints' => [],
             'integrity' => [],
@@ -59,7 +59,7 @@ final class EntrypointsTest extends TestCase
 
         $this->assertNotNull($devServer);
         $this->assertSame('http://localhost:5173', $devServer->origin);
-        $this->assertSame('vite', $devServer->client);
+        $this->assertSame('http://localhost:5173/build/@vite/client', $devServer->client);
     }
 
     public function testFromArrayDefaultsMissingOptionalSections()

--- a/tests/Asset/TagRendererTest.php
+++ b/tests/Asset/TagRendererTest.php
@@ -1,0 +1,371 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Tests\Asset;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\Asset\PathPackage;
+use Symfony\Component\Asset\UrlPackage;
+use Symfony\Component\Asset\VersionStrategy\EmptyVersionStrategy;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\WebLink\GenericLinkProvider;
+use Symfony\Reprise\Asset\DevServer;
+use Symfony\Reprise\Asset\EntrypointsLookupInterface;
+use Symfony\Reprise\Asset\TagRenderer;
+
+final class TagRendererTest extends TestCase
+{
+    private function renderer(
+        array $js = [],
+        array $css = [],
+        array $preload = [],
+        array $integrity = [],
+        ?DevServer $devServer = null,
+        string|false $crossorigin = false,
+        array $scriptAttributes = [],
+        array $linkAttributes = [],
+        ?RequestStack $requestStack = null,
+        bool $preloadEnabled = true,
+        ?Packages $packages = null,
+    ): TagRenderer {
+        $lookup = new class($js, $css, $preload, $integrity, $devServer) implements EntrypointsLookupInterface {
+            public function __construct(
+                private array $js,
+                private array $css,
+                private array $preload,
+                private array $integrity,
+                private ?DevServer $devServer,
+            ) {
+            }
+
+            public function getJavaScriptFiles(string $entryName): array
+            {
+                return $this->js;
+            }
+
+            public function getCssFiles(string $entryName): array
+            {
+                return $this->css;
+            }
+
+            public function getPreloadFiles(string $entryName): array
+            {
+                return $this->preload;
+            }
+
+            public function getDynamicFiles(string $entryName): array
+            {
+                return [];
+            }
+
+            public function entryExists(string $entryName): bool
+            {
+                return true;
+            }
+
+            public function getIntegrityData(): array
+            {
+                return $this->integrity;
+            }
+
+            public function isProd(): bool
+            {
+                return null === $this->devServer;
+            }
+
+            public function getDevServer(): ?DevServer
+            {
+                return $this->devServer;
+            }
+
+            public function reset(): void
+            {
+            }
+        };
+
+        $packages ??= new Packages(new PathPackage('/', new EmptyVersionStrategy()));
+
+        return new TagRenderer(
+            $lookup,
+            $packages,
+            $requestStack,
+            null,
+            $crossorigin,
+            $preloadEnabled,
+            $scriptAttributes,
+            $linkAttributes,
+        );
+    }
+
+    public function testRendersModuleScriptTagsWithPackagesResolvedSrc()
+    {
+        $html = $this->renderer(js: ['build/app-a1b2.js'])->renderScriptTags('app');
+        $this->assertSame('<script src="/build/app-a1b2.js" type="module"></script>', $html);
+    }
+
+    public function testRendersStylesheetLinkTags()
+    {
+        $html = $this->renderer(css: ['build/app-c3.css'])->renderLinkTags('app');
+        $this->assertSame('<link rel="stylesheet" href="/build/app-c3.css">', $html);
+    }
+
+    public function testAddsIntegrityAndCrossoriginWhenPresent()
+    {
+        $html = $this->renderer(
+            js: ['build/app-a1b2.js'],
+            integrity: ['build/app-a1b2.js' => 'sha384-XYZ'],
+        )->renderScriptTags('app');
+        $this->assertStringContainsString('integrity="sha384-XYZ"', $html);
+        $this->assertStringContainsString('crossorigin="anonymous"', $html);
+    }
+
+    public function testNoCrossoriginWithoutIntegrity()
+    {
+        $html = $this->renderer(js: ['build/app-a1b2.js'])->renderScriptTags('app');
+        $this->assertStringNotContainsString('crossorigin', $html);
+    }
+
+    public function testGetJsFilesReturnsResolvedUrlsWithoutTags()
+    {
+        $urls = $this->renderer(js: ['build/app-a1b2.js', 'build/vendor-e5.js'])->getJsFiles('app');
+        $this->assertSame(['/build/app-a1b2.js', '/build/vendor-e5.js'], $urls);
+    }
+
+    public function testScriptAndLinkDefaultAttributesAreApplied()
+    {
+        $html = $this->renderer(js: ['build/app.js'], scriptAttributes: ['defer' => true])->renderScriptTags('app');
+        $this->assertStringContainsString(' defer', $html);
+    }
+
+    public function testInjectsViteHmrClientOncePerRequestInDev()
+    {
+        $renderer = $this->renderer(
+            js: ['http://127.0.0.1:5173/build/app.js'],
+            devServer: new DevServer('http://127.0.0.1:5173', 'http://127.0.0.1:5173/build/@vite/client'),
+        );
+
+        $first = $renderer->renderScriptTags('app');
+        $this->assertSame(
+            '<script type="module" src="http://127.0.0.1:5173/build/@vite/client"></script>'
+            .'<script src="http://127.0.0.1:5173/build/app.js" type="module"></script>',
+            $first,
+        );
+
+        // Same request, second call (e.g. a second entry): the client is not injected again.
+        $second = $renderer->renderScriptTags('app');
+        $this->assertStringNotContainsString('@vite/client', $second);
+
+        // A new request resets the flag and the client is injected again.
+        $renderer->reset();
+        $this->assertStringContainsString('@vite/client', $renderer->renderScriptTags('app'));
+    }
+
+    public function testDoesNotInjectHmrClientWhenDevServerClientIsNull()
+    {
+        $html = $this->renderer(
+            js: ['http://127.0.0.1:5173/build/app.js'],
+            devServer: new DevServer('http://127.0.0.1:5173', null),
+        )->renderScriptTags('app');
+
+        $this->assertStringNotContainsString('@vite/client', $html);
+    }
+
+    public function testDoesNotInjectHmrClientInProd()
+    {
+        $html = $this->renderer(js: ['build/app-a1b2.js'])->renderScriptTags('app');
+
+        $this->assertStringNotContainsString('@vite/client', $html);
+    }
+
+    public function testRendersModulepreloadLinksWithIntegrityBeforeScripts()
+    {
+        $html = $this->renderer(
+            js: ['build/app-a1b2.js'],
+            preload: ['build/shared-e5.js'],
+            integrity: ['build/shared-e5.js' => 'sha384-shared'],
+        )->renderScriptTags('app');
+
+        $this->assertSame(
+            '<link rel="modulepreload" href="/build/shared-e5.js" integrity="sha384-shared" crossorigin="anonymous">'
+            .'<script src="/build/app-a1b2.js" type="module"></script>',
+            $html,
+        );
+    }
+
+    public function testRegistersPreloadLinksOnTheRequestWhenWebLinkIsAvailable()
+    {
+        $stack = new RequestStack();
+        $stack->push($request = new Request());
+
+        $renderer = $this->renderer(
+            js: ['build/app-a1b2.js'],
+            css: ['build/app-c3.css'],
+            preload: ['build/shared-e5.js'],
+            requestStack: $stack,
+        );
+        $renderer->renderScriptTags('app');
+        $renderer->renderLinkTags('app');
+
+        $links = $request->attributes->get('_links');
+        $this->assertInstanceOf(GenericLinkProvider::class, $links);
+
+        $byHref = [];
+        foreach ($links->getLinks() as $link) {
+            $byHref[$link->getHref()] = ['rels' => $link->getRels(), 'as' => $link->getAttributes()['as'] ?? null];
+        }
+
+        $this->assertSame(['modulepreload'], $byHref['/build/shared-e5.js']['rels']);
+        $this->assertSame(['preload'], $byHref['/build/app-a1b2.js']['rels']);
+        $this->assertSame('script', $byHref['/build/app-a1b2.js']['as']);
+        $this->assertSame(['preload'], $byHref['/build/app-c3.css']['rels']);
+        $this->assertSame('style', $byHref['/build/app-c3.css']['as']);
+    }
+
+    public function testDoesNotRegisterLinksWithoutACurrentRequest()
+    {
+        $renderer = $this->renderer(js: ['build/app-a1b2.js'], requestStack: new RequestStack());
+
+        // No current request pushed: rendering must not throw and returns the tags as usual.
+        $this->assertStringContainsString('<script', $renderer->renderScriptTags('app'));
+    }
+
+    public function testPreloadToggleDisablesLinkRegistration()
+    {
+        $stack = new RequestStack();
+        $stack->push($request = new Request());
+
+        $this->renderer(js: ['build/app-a1b2.js'], requestStack: $stack, preloadEnabled: false)
+            ->renderScriptTags('app');
+
+        $this->assertNull($request->attributes->get('_links'));
+    }
+
+    public function testConfiguredCrossoriginOverridesTheAnonymousDefault()
+    {
+        $html = $this->renderer(
+            js: ['build/app.js'],
+            integrity: ['build/app.js' => 'sha384-XYZ'],
+            crossorigin: 'use-credentials',
+        )->renderScriptTags('app');
+
+        $this->assertSame(
+            '<script src="/build/app.js" type="module" integrity="sha384-XYZ" crossorigin="use-credentials"></script>',
+            $html,
+        );
+    }
+
+    public function testLinkTagsGetIntegrityAndCrossoriginWhenPresent()
+    {
+        $html = $this->renderer(
+            css: ['build/app.css'],
+            integrity: ['build/app.css' => 'sha384-CSS'],
+        )->renderLinkTags('app');
+
+        $this->assertSame(
+            '<link rel="stylesheet" href="/build/app.css" integrity="sha384-CSS" crossorigin="anonymous">',
+            $html,
+        );
+    }
+
+    public function testResolvesReferencesThroughAnExplicitPackage()
+    {
+        $packages = new Packages(
+            new PathPackage('/', new EmptyVersionStrategy()),
+            ['cdn' => new UrlPackage('https://cdn.example.com/', new EmptyVersionStrategy())],
+        );
+
+        $html = $this->renderer(js: ['build/app.js'], packages: $packages)->renderScriptTags('app', 'cdn');
+
+        $this->assertSame('<script src="https://cdn.example.com/build/app.js" type="module"></script>', $html);
+    }
+
+    public function testGetCssFilesReturnsResolvedUrlsWithoutTags()
+    {
+        $urls = $this->renderer(css: ['build/a.css', 'build/b.css'])->getCssFiles('app');
+
+        $this->assertSame(['/build/a.css', '/build/b.css'], $urls);
+    }
+
+    public function testLinkAttributesAreApplied()
+    {
+        $html = $this->renderer(css: ['build/app.css'], linkAttributes: ['media' => 'print'])->renderLinkTags('app');
+
+        $this->assertSame('<link rel="stylesheet" href="/build/app.css" media="print">', $html);
+    }
+
+    public function testFalseValuedAttributeIsDropped()
+    {
+        $html = $this->renderer(js: ['build/app.js'], scriptAttributes: ['nomodule' => false])->renderScriptTags('app');
+
+        $this->assertSame('<script src="/build/app.js" type="module"></script>', $html);
+    }
+
+    public function testAttributeValuesAreHtmlEscaped()
+    {
+        $html = $this->renderer(
+            js: ['build/app.js'],
+            scriptAttributes: ['data-payload' => '"><script>alert(1)</script>'],
+        )->renderScriptTags('app');
+
+        // Exact match: the raw payload is fully escaped (no attribute-injection XSS) and nothing else
+        // leaks into the tag.
+        $this->assertSame(
+            '<script src="/build/app.js" type="module" data-payload="&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;"></script>',
+            $html,
+        );
+    }
+
+    public function testAnEntryWithNoFilesRendersAnEmptyString()
+    {
+        $renderer = $this->renderer();
+
+        $this->assertSame('', $renderer->renderScriptTags('app'));
+        $this->assertSame('', $renderer->renderLinkTags('app'));
+    }
+
+    public function testRendersEveryScriptInFileOrder()
+    {
+        // Load order is the whole point of entrypoints.json: the runtime chunk must precede the app
+        // chunk, in the exact order the file lists them.
+        $html = $this->renderer(js: ['build/runtime.js', 'build/app.js'])->renderScriptTags('app');
+
+        $this->assertSame(
+            '<script src="/build/runtime.js" type="module"></script>'
+            .'<script src="/build/app.js" type="module"></script>',
+            $html,
+        );
+    }
+
+    public function testRendersEveryStylesheetInFileOrder()
+    {
+        $html = $this->renderer(css: ['build/a.css', 'build/b.css'])->renderLinkTags('app');
+
+        $this->assertSame(
+            '<link rel="stylesheet" href="/build/a.css">'
+            .'<link rel="stylesheet" href="/build/b.css">',
+            $html,
+        );
+    }
+
+    public function testModulepreloadHasNoIntegrityWhenTheChunkIsNotHashed()
+    {
+        // A preload chunk without an SRI entry (e.g. in dev) gets a bare modulepreload link.
+        $html = $this->renderer(js: ['build/app.js'], preload: ['build/shared.js'])->renderScriptTags('app');
+
+        $this->assertSame(
+            '<link rel="modulepreload" href="/build/shared.js">'
+            .'<script src="/build/app.js" type="module"></script>',
+            $html,
+        );
+    }
+}

--- a/tests/EventListener/ResetAssetsEventListenerTest.php
+++ b/tests/EventListener/ResetAssetsEventListenerTest.php
@@ -38,7 +38,7 @@ final class ResetAssetsEventListenerTest extends TestCase
         new ResetAssetsEventListener($lookup)->onFinishRequest($this->finishRequest(HttpKernelInterface::MAIN_REQUEST));
 
         // After the reset the shared chunk is offered again to the next request.
-        $this->assertSame(['/build/shared-e5f6.js'], $lookup->getPreloadFiles('admin'));
+        $this->assertSame(['build/shared-e5f6.js'], $lookup->getPreloadFiles('admin'));
     }
 
     public function testIgnoresSubRequests()

--- a/tests/Functional/AssetTagsTest.php
+++ b/tests/Functional/AssetTagsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Tests\Functional;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Reprise\Asset\TagRenderer;
+use Symfony\Reprise\Exception\EntrypointNotFoundException;
+use Symfony\Reprise\Tests\Kernel\FunctionalAppKernel;
+
+final class AssetTagsTest extends TestCase
+{
+    private function renderer(): TagRenderer
+    {
+        $kernel = new FunctionalAppKernel(__DIR__.'/../fixtures/build');
+        $kernel->boot();
+
+        return $kernel->getContainer()->get('reprise.tag_renderer');
+    }
+
+    public function testScriptTagsRenderTheEntryWithResolvedUrlAndIntegrity()
+    {
+        // `app.js` is a relative entrypoints reference (`build/app-a1b2.js`) resolved through the
+        // framework asset package (version-less) to an absolute path, and it carries an SRI hash in
+        // the fixture's `integrity` map, so the tag also gets `integrity` + `crossorigin`.
+        $expected = <<<'HTML'
+            <link rel="modulepreload" href="/build/shared-e5f6.js" integrity="sha384-shared" crossorigin="anonymous"><script src="/build/app-a1b2.js" type="module" integrity="sha384-app" crossorigin="anonymous"></script>
+            HTML;
+
+        $this->assertSame($expected, $this->renderer()->renderScriptTags('app'));
+    }
+
+    public function testLinkTagsRenderTheEntryStylesheet()
+    {
+        // `app.css` (`build/app-c3d4.css`) has no SRI hash in the fixture, so no integrity/crossorigin.
+        $expected = <<<'HTML'
+            <link rel="stylesheet" href="/build/app-c3d4.css">
+            HTML;
+
+        $this->assertSame($expected, $this->renderer()->renderLinkTags('app'));
+    }
+
+    public function testStrictModeThrowsWhenRenderingAnUnknownEntry()
+    {
+        // strict_mode defaults to true, so a missing entry surfaces as a clear exception end-to-end
+        // (through the booted kernel and the real EntrypointsLookup), rather than silent empty output.
+        $this->expectException(EntrypointNotFoundException::class);
+
+        $this->renderer()->renderScriptTags('does-not-exist');
+    }
+}

--- a/tests/Functional/DevAssetTagsTest.php
+++ b/tests/Functional/DevAssetTagsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Tests\Functional;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Reprise\Asset\TagRenderer;
+use Symfony\Reprise\Tests\Kernel\FunctionalAppKernel;
+
+final class DevAssetTagsTest extends TestCase
+{
+    private function renderer(string $fixture): TagRenderer
+    {
+        $kernel = new FunctionalAppKernel(__DIR__.'/../fixtures/'.$fixture);
+        $kernel->boot();
+
+        return $kernel->getContainer()->get('reprise.tag_renderer');
+    }
+
+    public function testViteDevInjectsTheHmrClientAndServesFromTheOrigin()
+    {
+        // Vite dev emits the HMR client URL (served under `base`, so `/build/@vite/client`); it is
+        // injected once, before the entry script, whose src is the dev-server origin URL passed
+        // through by Packages unchanged.
+        $expected = <<<'HTML'
+            <script type="module" src="http://127.0.0.1:5173/build/@vite/client"></script><script src="http://127.0.0.1:5173/build/app.js" type="module"></script>
+            HTML;
+
+        $this->assertSame($expected, $this->renderer('dev')->renderScriptTags('app'));
+    }
+
+    public function testRsbuildDevServesFromTheOriginWithNoClientInjection()
+    {
+        // Rsbuild dev emits `client: null` (its HMR client is compiled into the bundle), so nothing
+        // is injected; the entry script still loads from the dev-server origin.
+        $expected = <<<'HTML'
+            <script src="http://127.0.0.1:3000/build/app.js" type="module"></script>
+            HTML;
+
+        $this->assertSame($expected, $this->renderer('dev-rspack')->renderScriptTags('app'));
+    }
+}

--- a/tests/Functional/EntrypointsLookupTest.php
+++ b/tests/Functional/EntrypointsLookupTest.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Reprise\Tests\Asset;
+namespace Symfony\Reprise\Tests\Functional;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Reprise\Asset\EntrypointsLookupInterface;
 use Symfony\Reprise\Tests\Kernel\FunctionalAppKernel;
 use Symfony\Reprise\Tests\Kernel\LookupConsumer;
 
-final class EntrypointsLookupFunctionalTest extends TestCase
+final class EntrypointsLookupTest extends TestCase
 {
     public function testTheLookupIsWiredFromConfigAndResolvesAnEntry()
     {
@@ -26,7 +26,7 @@ final class EntrypointsLookupFunctionalTest extends TestCase
         $lookup = $kernel->getContainer()->get(EntrypointsLookupInterface::class);
 
         $this->assertInstanceOf(EntrypointsLookupInterface::class, $lookup);
-        $this->assertSame(['/build/app-a1b2.js'], $lookup->getJavaScriptFiles('app'));
+        $this->assertSame(['build/app-a1b2.js'], $lookup->getJavaScriptFiles('app'));
         $this->assertTrue($lookup->isProd());
     }
 
@@ -38,6 +38,6 @@ final class EntrypointsLookupFunctionalTest extends TestCase
         $consumer = $kernel->getContainer()->get(LookupConsumer::class);
 
         $this->assertInstanceOf(LookupConsumer::class, $consumer);
-        $this->assertSame(['/build/app-a1b2.js'], $consumer->lookup->getJavaScriptFiles('app'));
+        $this->assertSame(['build/app-a1b2.js'], $consumer->lookup->getJavaScriptFiles('app'));
     }
 }

--- a/tests/Kernel/FunctionalAppKernel.php
+++ b/tests/Kernel/FunctionalAppKernel.php
@@ -20,15 +20,20 @@ use Symfony\Reprise\Asset\EntrypointsLookupInterface;
 use Symfony\Reprise\RepriseBundle;
 
 /**
- * A framework kernel wired with a given Reprise `output_path`, exposing the lookup service
- * publicly so functional tests can fetch it from the container.
+ * A framework kernel wired with a given Reprise `output_path`, exposing the lookup and the tag
+ * renderer publicly so functional tests can fetch them from the container.
  */
 final class FunctionalAppKernel extends Kernel implements CompilerPassInterface
 {
     use AppKernelTrait;
 
-    public function __construct(private readonly string $outputPath)
-    {
+    /**
+     * @param array<string, mixed> $repriseConfig extra reprise config merged over `output_path`
+     */
+    public function __construct(
+        private readonly string $outputPath,
+        private readonly array $repriseConfig = [],
+    ) {
         parent::__construct('test', true);
     }
 
@@ -47,6 +52,7 @@ final class FunctionalAppKernel extends Kernel implements CompilerPassInterface
             ]);
             $container->loadFromExtension('reprise', [
                 'output_path' => $this->outputPath,
+                ...$this->repriseConfig,
             ]);
 
             // A user-land service autowiring the lookup by its interface.
@@ -64,5 +70,6 @@ final class FunctionalAppKernel extends Kernel implements CompilerPassInterface
     public function process(ContainerBuilder $container): void
     {
         $container->getAlias(EntrypointsLookupInterface::class)->setPublic(true);
+        $container->getDefinition('reprise.tag_renderer')->setPublic(true);
     }
 }

--- a/tests/RepriseBundleTest.php
+++ b/tests/RepriseBundleTest.php
@@ -13,9 +13,11 @@ namespace Symfony\Reprise\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Reprise\Tests\Kernel\EmptyAppKernel;
 use Symfony\Reprise\Tests\Kernel\FrameworkAppKernel;
+use Symfony\Reprise\Tests\Kernel\FunctionalAppKernel;
 
 final class RepriseBundleTest extends TestCase
 {
@@ -34,5 +36,14 @@ final class RepriseBundleTest extends TestCase
         $kernel->boot();
 
         $this->assertArrayHasKey('RepriseBundle', $kernel->getBundles());
+    }
+
+    public function testRejectsAnInvalidCrossoriginValue()
+    {
+        // crossorigin is an enum: any value other than false/anonymous/use-credentials is a config
+        // error surfaced at container-compile time, not silently rendered onto the tags.
+        $this->expectException(InvalidConfigurationException::class);
+
+        new FunctionalAppKernel(__DIR__.'/fixtures/build', ['crossorigin' => 'not-valid'])->boot();
     }
 }

--- a/tests/Twig/AssetExtensionTest.php
+++ b/tests/Twig/AssetExtensionTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Tests\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\Asset\PathPackage;
+use Symfony\Component\Asset\VersionStrategy\EmptyVersionStrategy;
+use Symfony\Reprise\Asset\DevServer;
+use Symfony\Reprise\Asset\EntrypointsLookupInterface;
+use Symfony\Reprise\Asset\TagRenderer;
+use Symfony\Reprise\Twig\AssetExtension;
+use Symfony\Reprise\Twig\AssetRuntime;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\RuntimeLoader\FactoryRuntimeLoader;
+
+final class AssetExtensionTest extends TestCase
+{
+    public function testFunctionsRenderThroughALazilyBuiltRuntime()
+    {
+        $built = 0;
+        $twig = new Environment(new ArrayLoader([
+            'page' => "{{ reprise_entry_script_tags('app') }}",
+        ]));
+        $twig->addExtension(new AssetExtension());
+        $twig->addRuntimeLoader(new FactoryRuntimeLoader([
+            AssetRuntime::class => function () use (&$built): AssetRuntime {
+                ++$built;
+
+                return new AssetRuntime($this->tagRenderer(['build/app.js']));
+            },
+        ]));
+
+        // Registering the extension must not build the runtime (nor the TagRenderer behind it).
+        $this->assertSame(0, $built);
+
+        $html = $twig->render('page');
+
+        // The runtime is built exactly once, on first use, and its output flows through unescaped
+        // (the functions are declared is_safe: html).
+        $this->assertSame(1, $built);
+        $this->assertSame('<script src="/build/app.js" type="module"></script>', $html);
+    }
+
+    public function testAllFourFunctionsDelegateThroughTheRuntime()
+    {
+        $twig = new Environment(new ArrayLoader([
+            'page' => "{{ reprise_entry_script_tags('app') }}|{{ reprise_entry_link_tags('app') }}"
+                ."|{{ reprise_entry_js_files('app')|join(',') }}|{{ reprise_entry_css_files('app')|join(',') }}",
+        ]));
+        $twig->addExtension(new AssetExtension());
+        $twig->addRuntimeLoader(new FactoryRuntimeLoader([
+            AssetRuntime::class => fn (): AssetRuntime => new AssetRuntime(
+                $this->tagRenderer(['build/app.js'], ['build/app.css']),
+            ),
+        ]));
+
+        $this->assertSame(
+            '<script src="/build/app.js" type="module"></script>'
+            .'|<link rel="stylesheet" href="/build/app.css">'
+            .'|/build/app.js|/build/app.css',
+            $twig->render('page'),
+        );
+    }
+
+    /**
+     * @param list<string> $js
+     * @param list<string> $css
+     */
+    private function tagRenderer(array $js = [], array $css = []): TagRenderer
+    {
+        $lookup = new class($js, $css) implements EntrypointsLookupInterface {
+            /**
+             * @param list<string> $js
+             * @param list<string> $css
+             */
+            public function __construct(private array $js, private array $css)
+            {
+            }
+
+            public function getJavaScriptFiles(string $entryName): array
+            {
+                return $this->js;
+            }
+
+            public function getCssFiles(string $entryName): array
+            {
+                return $this->css;
+            }
+
+            public function getPreloadFiles(string $entryName): array
+            {
+                return [];
+            }
+
+            public function getDynamicFiles(string $entryName): array
+            {
+                return [];
+            }
+
+            public function entryExists(string $entryName): bool
+            {
+                return true;
+            }
+
+            public function getIntegrityData(): array
+            {
+                return [];
+            }
+
+            public function isProd(): bool
+            {
+                return true;
+            }
+
+            public function getDevServer(): ?DevServer
+            {
+                return null;
+            }
+
+            public function reset(): void
+            {
+            }
+        };
+
+        return new TagRenderer($lookup, new Packages(new PathPackage('/', new EmptyVersionStrategy())));
+    }
+}

--- a/tests/fixtures/build/entrypoints.json
+++ b/tests/fixtures/build/entrypoints.json
@@ -4,20 +4,20 @@
     "publicPath": "/build/",
     "entryPoints": {
         "app": {
-            "js": ["/build/app-a1b2.js"],
-            "css": ["/build/app-c3d4.css"],
-            "preload": ["/build/shared-e5f6.js"],
-            "dynamic": ["/build/lazy-x.js"]
+            "js": ["build/app-a1b2.js"],
+            "css": ["build/app-c3d4.css"],
+            "preload": ["build/shared-e5f6.js"],
+            "dynamic": ["build/lazy-x.js"]
         },
         "admin": {
-            "js": ["/build/admin-99.js"],
+            "js": ["build/admin-99.js"],
             "css": [],
-            "preload": ["/build/shared-e5f6.js"],
+            "preload": ["build/shared-e5f6.js"],
             "dynamic": []
         }
     },
     "integrity": {
-        "/build/app-a1b2.js": "sha384-app",
-        "/build/shared-e5f6.js": "sha384-shared"
+        "build/app-a1b2.js": "sha384-app",
+        "build/shared-e5f6.js": "sha384-shared"
     }
 }

--- a/tests/fixtures/dev-rspack/entrypoints.json
+++ b/tests/fixtures/dev-rspack/entrypoints.json
@@ -1,10 +1,10 @@
 {
     "isProd": false,
-    "devServer": { "origin": "http://127.0.0.1:5173", "client": "http://127.0.0.1:5173/build/@vite/client" },
+    "devServer": { "origin": "http://127.0.0.1:3000", "client": null },
     "publicPath": "/build/",
     "entryPoints": {
         "app": {
-            "js": ["http://127.0.0.1:5173/build/app.js"],
+            "js": ["http://127.0.0.1:3000/build/app.js"],
             "css": [],
             "preload": [],
             "dynamic": []


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This adds the part of Reprise people actually template against: rendering an entry's `<script>`/`<link>` tags in Twig, straight from `entrypoints.json`. It's the same experience Webpack Encore gives with `encore_entry_script_tags` / `encore_entry_link_tags`, ported to Reprise's naming. Four functions ship: `reprise_entry_script_tags`, `reprise_entry_link_tags`, `reprise_entry_js_files`, `reprise_entry_css_files`.

URL resolution follows ADR 0001: Vite and Rsbuild emit docroot-relative, content-hashed references in `entrypoints.json`, and the PHP side turns each one into a URL through `symfony/asset` `Packages`. A plain project needs no setup beyond installing the bundle: the default asset package resolves `build/app.js` to `/build/app.js`. For a CDN, either set `publicPath` to the CDN URL at build time (the existing Encore way) or point Reprise at a version-less `framework.assets` package.

What's included:

- Dev server support: `reprise_entry_script_tags` injects the Vite HMR client automatically, once per request. Rsbuild bundles its HMR client into the entry itself, so nothing extra gets emitted there. Either way, there's nothing to configure.
- Preload chunks render as `<link rel="modulepreload">`.
- Subresource Integrity: `integrity` and `crossorigin` attributes are applied when a file carries an SRI hash. `crossorigin` is a config enum (`false` | `'anonymous'` | `'use-credentials'`).
- WebLink integration: when `symfony/web-link` is installed, rendered assets also get registered as HTTP/2 `Link:` preload headers (toggle via the `preload` option).
- Both Vite and Rsbuild standardize on ESM output, so `type="module"` is always correct, no branching needed.
- The Twig extension only declares the functions; the actual renderer lives in a lazily-loaded Twig runtime, so pages that never call a `reprise_*` function don't build it.

## Usage

```twig
{# templates/base.html.twig #}
<head>
    {{ reprise_entry_link_tags('app') }}
    {{ reprise_entry_script_tags('app') }}
</head>
```

Config is optional and mirrors what you'd expect from Encore:

```yaml
# config/packages/reprise.yaml
reprise:
    output_path: '%kernel.project_dir%/public/build'
    crossorigin: false
    preload: true
```

## Testing and docs

Full PHP test suite with 100% line coverage of `src/`, plus the usual mirrored Vite/Rsbuild functional tests. Documentation gets a new "Rendering asset tags" section in `doc/index.rst`.
