### PR TITLE
[CI] Publish the npm package on tags via trusted publishing

### DIFF
--- a/.github/workflows/release-on-npm.yaml
+++ b/.github/workflows/release-on-npm.yaml
@@ -1,0 +1,56 @@
+name: Release on NPM
+
+on:
+    push:
+        tags:
+            - 'v*.*.*'
+
+permissions:
+    id-token: write # Required for OIDC
+    contents: read
+
+concurrency:
+    group: release-on-npm-${{ github.ref_name }}
+    cancel-in-progress: false
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  ref: ${{ github.ref }}
+                  persist-credentials: false
+                  fetch-depth: 0
+
+            - name: Verify tag is on the main branch
+              run: |
+                  set -euo pipefail
+                  git fetch --no-tags origin refs/heads/main:refs/remotes/origin/main
+                  if ! git merge-base --is-ancestor "${GITHUB_SHA}" refs/remotes/origin/main; then
+                      echo "::error::Tag ${GITHUB_REF_NAME} (${GITHUB_SHA}) is not an ancestor of main. Refusing to publish."
+                      exit 1
+                  fi
+                  echo "Tag ${GITHUB_REF_NAME} verified as ancestor of main."
+
+            # Pinned explicitly to avoid pulling a compromised "latest" at release time; bump via dedicated PR.
+            - run: npm i -g corepack@0.35.0 && corepack enable
+              # setup-node does not enable any package-manager cache here (no `cache:` input),
+              # so cache poisoning is not a concern on this release workflow.
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # zizmor: ignore[cache-poisoning] v6.4.0
+              with:
+                  registry-url: 'https://registry.npmjs.org'
+                  node-version-file: '.nvmrc'
+
+              # npm 11.5.1 or later is required for OIDC. Pinned explicitly to avoid
+              # pulling a compromised "latest" at release time; bump via dedicated PR.
+            - run: npm install -g npm@11.16.0
+
+            - name: Install root JS dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Build JS assets
+              run: pnpm run build
+
+            - name: Publish on NPM
+              run: pnpm publish --recursive --access public --no-git-checks --provenance


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Adds a `Release on NPM` workflow that publishes `@symfony/reprise` to npm when a `v*.*.*` tag is pushed. It's modeled closely on the battle-tested `symfony/ux` workflow.

- **Trusted publishing (OIDC)**: no `NPM_TOKEN`, just `id-token: write`. npm generates provenance automatically. Requires the package's trusted publisher to be configured on npmjs.com to point at this repo and the `release-on-npm.yaml` workflow.
- **Guardrails from symfony/ux**: pinned action SHAs, `persist-credentials: false`, a pinned `npm@11.16.0` (OIDC needs >= 11.5.1), `pnpm install --frozen-lockfile`, and `pnpm publish --recursive --access public --no-git-checks --provenance`.
- **Adapted for Reprise**: the tag pattern is `v*.*.*`, the "tag is on a release branch" check targets `main` (Reprise has no `X.x` branches), and there's no committed-dist verification step -- Reprise gitignores `assets/dist` and builds it in CI, so there's nothing committed to diff against.

`--recursive` only reaches `@symfony/reprise`: the monorepo root and the `playground` package are both `private`.
