### PR TITLE
[CI] Add a release script and maintainers guide

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@
 /.symfony.bundle.yaml export-ignore
 /AGENTS.md export-ignore
 /CLAUDE.md export-ignore
+/MAINTAINERS.md export-ignore
 /assets export-ignore
 /docs export-ignore
 /package.json export-ignore
@@ -19,4 +20,5 @@
 /pnpm-lock.yaml export-ignore
 /pnpm-workspace.yaml export-ignore
 /reference-repos.md export-ignore
+/release.sh export-ignore
 /tests export-ignore

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,51 @@
+# Maintainers guide
+
+This document describes how the Reprise maintainers cut a release.
+
+## Releasing
+
+This repository ships two packages, released together from a single Git tag:
+
+- the Composer bundle `symfony/reprise`, published to Packagist from the tag;
+- the npm plugin `@symfony/reprise`, published to npm by the
+  [`release-on-npm.yaml`](.github/workflows/release-on-npm.yaml) workflow.
+
+### Prerequisites
+
+- Push access to the `upstream` remote (`git@github.com:symfony/reprise.git`).
+- The npm package's trusted publisher configured on npmjs.com to point at the `symfony/reprise` repository
+  and the `release-on-npm.yaml` workflow. This is what lets the workflow publish without an `NPM_TOKEN`.
+
+### Steps
+
+1. Start from an up-to-date `main`:
+
+    ```bash
+    git checkout main
+    git pull upstream main
+    ```
+
+2. Cut the release commit and tag with the helper script, passing the bump level:
+
+    ```bash
+    ./release.sh minor   # or patch / major / an explicit version such as 0.2.0
+    ```
+
+    It checks that you are on a clean `main` in sync with `upstream`, then runs `pnpm version` inside
+    `assets/` (the publishable package) to bump `assets/package.json`, commit, and create the `v<version>`
+    tag. Running `pnpm version` from the repo root would target the private root package, and `--filter`
+    would skip the commit and tag -- that is why the script scopes it to `assets/`.
+
+3. Push `main` and the new tag to upstream:
+
+    ```bash
+    git push upstream main --follow-tags
+    ```
+
+4. Pushing the `v<version>` tag triggers
+   [`release-on-npm.yaml`](.github/workflows/release-on-npm.yaml), which publishes `@symfony/reprise` to
+   npm through OIDC trusted publishing. The workflow refuses to publish a tag that isn't on `main`.
+   Packagist picks up the same tag for the Composer package.
+
+5. Write the release notes on GitHub (**Releases -> Draft a new release**), select the `v<version>` tag,
+   and generate the changelog.

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@symfony/reprise",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Symfony asset integration for Vite and Rsbuild, a reprise of Webpack Encore.",
   "license": "MIT",
   "author": {

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Cut a release: bump the @symfony/reprise version, commit, and tag it.
+#
+# Usage: ./release.sh <patch|minor|major|x.y.z>
+#
+# It only prepares the commit and tag locally. Pushing the tag is left to you,
+# because that is what triggers the production publish (see MAINTAINERS.md).
+
+set -euo pipefail
+
+bump="${1:-}"
+if [ -z "$bump" ]; then
+    echo "Usage: $0 <patch|minor|major|x.y.z>" >&2
+    exit 1
+fi
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$branch" != "main" ]; then
+    echo "Error: releases are cut from 'main', but you are on '$branch'." >&2
+    exit 1
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Error: the working tree is not clean. Commit or stash your changes first." >&2
+    exit 1
+fi
+
+git fetch --quiet upstream main
+if [ "$(git rev-parse HEAD)" != "$(git rev-parse FETCH_HEAD)" ]; then
+    echo "Error: local 'main' is not in sync with 'upstream/main'. Pull first." >&2
+    exit 1
+fi
+
+# Run pnpm version inside assets/, the publishable package: from the repo root it would target the
+# private root package, and with --filter pnpm skips the commit and tag. This bumps
+# assets/package.json, commits the change, and creates the matching vX.Y.Z tag.
+(cd assets && pnpm version "$bump")
+
+version="$(node -p "require('./assets/package.json').version")"
+tag="v${version}"
+
+echo
+echo "Prepared ${tag}. Review the commit and tag, then publish with:"
+echo
+echo "    git push upstream main --follow-tags"
+echo
+echo "Pushing ${tag} triggers the Release on NPM workflow, which publishes to npm."


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Adds `release.sh` and a `MAINTAINERS.md` release guide so cutting a release is one guarded command.

`./release.sh <patch|minor|major>` runs `pnpm version` inside `assets/`, the publishable package. It has to run there: from the repo root `pnpm version` targets the private monorepo root, and with `--filter` pnpm skips the commit and tag -- so only running it inside the package produces the release commit and the `vX.Y.Z` tag. The script first checks you're on a clean `main` in sync with `upstream`, and it stops after creating the commit and tag, printing the `git push upstream main --follow-tags` command instead of pushing. Pushing the tag is what triggers the production npm publish via the Release on NPM workflow, so that step stays manual.

It also resets `assets/package.json` to `0.0.0`, since the package hasn't been published yet. The first release is then cut like any other (`./release.sh minor` -> `0.1.0`). Both `release.sh` and `MAINTAINERS.md` are `export-ignore`d from the Composer dist.
