### PR TITLE
[Docs] Reorganize the documentation layout

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -43,7 +43,7 @@ Then install the npm package:
     $ npm install @symfony/reprise --save-dev
 
 Vite
-----
+~~~~
 
 .. code-block:: javascript
 
@@ -52,6 +52,13 @@ Vite
     import Symfony from '@symfony/reprise/vite'
 
     export default defineConfig({
+      build: {
+        rollupOptions: {
+          input: {
+            app: './assets/app.js',
+          },
+        },
+      },
       plugins: [
         Symfony({
           // options
@@ -60,7 +67,7 @@ Vite
     })
 
 Rsbuild
--------
+~~~~~~~
 
 .. code-block:: javascript
 
@@ -69,6 +76,11 @@ Rsbuild
     import Symfony from '@symfony/reprise/rsbuild'
 
     export default defineConfig({
+      source: {
+        entry: {
+          app: './assets/app.js',
+        },
+      },
       plugins: [
         Symfony({
           // options
@@ -139,6 +151,287 @@ same whether Vite or Rsbuild produced ``entrypoints.json``, and there's nothing 
 ``reprise_entry_script_tags`` injects the Vite HMR client automatically, while under Rsbuild the client is compiled
 into the bundle.
 
+Features
+--------
+
+The rest of what Reprise carries over from Encore is opt-in. Turn on each feature through the plugin options in your
+``vite.config.ts`` or ``rsbuild.config.ts``, and leave out the ones you don't need.
+
+Symfony UX / Stimulus controllers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is the Vite/Rsbuild counterpart of what `@symfony/stimulus-bridge`_ did for Webpack Encore: it turns your
+``controllers.json`` into a Stimulus application, with the same enable step, same helper, same local-controllers
+convention.
+
+Enable it by pointing the plugin at your ``controllers.json`` (this is what turns the feature on):
+
+.. code-block:: javascript
+
+    Symfony({
+      stimulus: 'assets/controllers.json',
+    })
+    // or, to override the local controllers dir:
+    Symfony({
+      stimulus: {
+        controllersJson: 'assets/controllers.json',
+        controllersDir: 'assets/controllers',
+      },
+    })
+
+Then start the app from your entry:
+
+.. code-block:: javascript
+
+    import { startStimulusApp } from '@symfony/reprise/stimulus'
+
+    const app = startStimulusApp()
+
+**Local controllers.** Any ``assets/controllers/*_controller.{js,ts}`` is registered automatically. The filename
+becomes the identifier (``hello_controller.js`` becomes ``hello``, ``admin/user_controller.js`` becomes
+``admin--user``). To load a controller on demand, put a ``stimulusFetch: 'lazy'`` comment directly above the
+class; a block or a single-line comment both work.
+
+.. code-block:: javascript
+
+    import { Controller } from '@hotwired/stimulus'
+
+    /* stimulusFetch: 'lazy' */
+    export default class extends Controller {}
+
+(``// stimulusFetch: 'lazy'`` on the line above the class works too, as does a preserved
+``/*! stimulusFetch: 'lazy' */`` comment: the form tsc and esbuild keep through minification.)
+
+**Third-party UX packages.** Controllers declared in ``controllers.json`` are resolved from ``node_modules``, so
+install them with your package manager, the same as you would with Webpack Encore. For example, with Stimulus and
+UX Leaflet Map:
+
+.. code-block:: terminal
+
+    $ npm install @hotwired/stimulus @symfony/ux-leaflet-map
+
+Some packages need a bit of bundler-specific setup on top, the same way they did under Webpack Encore. UX Leaflet
+Map, for instance, ships a CSS file meant for Webpack's loader and needs an alias to the plain CSS build:
+
+.. code-block:: javascript
+
+    // vite.config.ts
+    export default defineConfig({
+      // ...
+      resolve: {
+        alias: {
+          'leaflet/dist/leaflet.min.css': 'leaflet/dist/leaflet.css',
+        },
+      },
+    })
+
+Check each package's own docs for this kind of tweak.
+
+File copy
+~~~~~~~~~
+
+Some assets aren't imported from JavaScript or CSS at all: they're referenced by a stable path straight from your
+templates, like ``{{ asset('build/images/logo.svg') }}``. Point ``copy`` at the directories that hold them and
+Reprise copies each file into the build and records it in ``manifest.json``. Once Symfony is pointed at that
+manifest (below), the ``asset()`` helper resolves the logical path to the hashed URL:
+
+.. code-block:: javascript
+
+    // vite.config.ts
+    import { defineConfig } from 'vite'
+    import Symfony from '@symfony/reprise/vite'
+
+    export default defineConfig({
+      // ...
+      plugins: [
+        Symfony({
+          copy: [
+            {
+              from: 'assets/images',
+              to: 'images',
+            },
+          ],
+        }),
+      ],
+    })
+
+.. code-block:: javascript
+
+    // rsbuild.config.ts
+    import { defineConfig } from '@rsbuild/core'
+    import Symfony from '@symfony/reprise/rsbuild'
+
+    export default defineConfig({
+      // ...
+      plugins: [
+        Symfony({
+          copy: [
+            {
+              from: 'assets/images',
+              to: 'images',
+            },
+          ],
+        }),
+      ],
+    })
+
+``from`` and ``to`` are both required: ``from`` is the source directory (relative to your project root), ``to`` is
+the destination prefix used for the manifest key. Restrict which files are copied with ``pattern``, a regular
+expression tested against each file's path relative to ``from`` (by default every file is copied).
+``includeSubdirectories`` defaults to ``true``; set it to ``false`` to turn off recursion.
+
+How copied files are handled depends on the mode:
+
+- **Build**: each file gets a content hash in its filename for cache busting.
+- **Dev**: files are copied verbatim, no hash.
+
+Either way they land in ``public/build`` and are served by the Symfony web server, not the Vite/Rsbuild dev server,
+so they're available whether or not the dev server is running.
+
+For ``asset()`` to return the hashed URL, point Symfony's asset component at the generated ``manifest.json`` with
+``framework.assets.json_manifest_path``:
+
+.. code-block:: yaml
+
+    # config/packages/framework.yaml
+    framework:
+        assets:
+            json_manifest_path: '%kernel.project_dir%/public/build/manifest.json'
+
+This is Symfony's native manifest support, the same setting Webpack Encore relies on, so it applies to every logical
+asset reference, not just copied files. The entry references that ``RepriseBundle`` renders already carry their hash
+and aren't manifest keys, so they pass through untouched.
+
+By default the lookup is lenient: a reference missing from the manifest is returned unchanged. Set
+``framework.assets.strict_mode: true`` to fail loudly on an unknown reference instead. Under strict mode, the entry
+references ``RepriseBundle`` renders would be rejected too, so route them through a package that skips the manifest:
+set ``reprise.asset_package`` to a package with ``version: false`` (see `Configuration`_) and keep
+``json_manifest_path`` on the default package for your other assets.
+
+Using a CDN
+~~~~~~~~~~~
+
+To serve your built assets from a CDN, set ``publicPath`` to the absolute CDN URL, for the production build only. In
+dev, the dev server serves assets directly, so keep the local ``/build/`` path there. Both bundlers expose the mode
+through the function form of their config, so switch on ``command === 'build'``:
+
+.. code-block:: javascript
+
+    // vite.config.ts  (command is 'serve' or 'build')
+    import { defineConfig } from 'vite'
+    import Symfony from '@symfony/reprise/vite'
+
+    export default defineConfig(({ command }) => ({
+      // ...
+      plugins: [
+        Symfony({
+          publicPath:
+            command === 'build'
+              ? 'https://my-cool-app.com.global.prod.fastly.net/build/'
+              : '/build/',
+          manifestKeyPrefix: 'build/',
+        }),
+      ],
+    }))
+
+.. code-block:: javascript
+
+    // rsbuild.config.ts  (command is 'dev' or 'build')
+    import { defineConfig } from '@rsbuild/core'
+    import Symfony from '@symfony/reprise/rsbuild'
+
+    export default defineConfig(({ command }) => ({
+      // ...
+      plugins: [
+        Symfony({
+          publicPath:
+            command === 'build'
+              ? 'https://my-cool-app.com.global.prod.fastly.net/build/'
+              : '/build/',
+          manifestKeyPrefix: 'build/',
+        }),
+      ],
+    }))
+
+With an absolute ``publicPath``, ``manifestKeyPrefix`` is **required**: Reprise has no way to guess the right prefix
+for the ``manifest.json`` keys, and throws a clear error if it's missing. Keys stay logical, values point at the
+CDN:
+
+.. code-block:: json
+
+    {
+      "build/app.js": "https://my-cool-app.com.global.prod.fastly.net/build/app-1a2b3c.js"
+    }
+
+``entrypoints.json`` is rewritten the same way, so the ``<script>`` and ``<link>`` tags render with CDN URLs. You
+still have to upload the built files to the CDN yourself, or set up origin pull. For a CDN subdirectory, include it
+in the URL (``https://my-cool-app.com.global.prod.fastly.net/awesome-website/build/``).
+
+Subresource Integrity
+~~~~~~~~~~~~~~~~~~~~~~~
+
+When enabled, Reprise adds an ``integrity`` map to ``entrypoints.json`` (asset URL -> SRI hash). ``RepriseBundle``
+reads that map and renders ``integrity="..."`` on the generated ``<script>`` and ``<link>`` tags, so the browser
+refuses any asset whose bytes were tampered with.
+
+The ``integrity`` option takes an object ``{ enabled, algorithms? }``. It only makes sense for the production build:
+the dev server serves changing in-memory assets, so no hashes are emitted in dev. As with the CDN example, toggle it
+with ``command === 'build'``:
+
+.. code-block:: javascript
+
+    // vite.config.ts  (command is 'serve' or 'build')
+    import { defineConfig } from 'vite'
+    import Symfony from '@symfony/reprise/vite'
+
+    export default defineConfig(({ command }) => ({
+      // ...
+      plugins: [
+        Symfony({
+          integrity: {
+            enabled: command === 'build',
+            algorithms: ['sha384'],
+          },
+        }),
+      ],
+    }))
+
+.. code-block:: javascript
+
+    // rsbuild.config.ts  (command is 'dev' or 'build')
+    import { defineConfig } from '@rsbuild/core'
+    import Symfony from '@symfony/reprise/rsbuild'
+
+    export default defineConfig(({ command }) => ({
+      // ...
+      plugins: [
+        Symfony({
+          integrity: {
+            enabled: command === 'build',
+            algorithms: ['sha384'],
+          },
+        }),
+      ],
+    }))
+
+``algorithms`` is optional and defaults to ``['sha384']``. Accepted values are ``'sha256'``, ``'sha384'`` and
+``'sha512'``. Passing several (e.g. ``['sha256', 'sha512']``) writes multiple space-separated hashes per file, which
+the browser treats as "any one of these must match".
+
+The resulting ``entrypoints.json`` gets an extra ``integrity`` section:
+
+.. code-block:: json
+
+    {
+      "integrity": {
+        "/build/app-1a2b3c.js": "sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K...",
+        "/build/app-4d5e6f.css": "sha384-9ehJ4G8v3aQ2p1o0..."
+      }
+    }
+
+Hashes cover every referenced file in each entry (js, css, and preloaded/dynamic chunks), and since they're computed
+from the files actually written to disk, they stay correct through minification and hashing.
+
 Configuration
 -------------
 
@@ -199,274 +492,6 @@ If you set ``asset_package``, define that package with ``version: false``:
             packages:
                 reprise:
                     version: false
-
-Symfony UX / Stimulus controllers
----------------------------------
-
-This is the Vite/Rsbuild counterpart of what `@symfony/stimulus-bridge`_ did for Webpack Encore: it turns your
-``controllers.json`` into a Stimulus application, with the same enable step, same helper, same local-controllers
-convention.
-
-Enable it by pointing the plugin at your ``controllers.json`` (this is what turns the feature on):
-
-.. code-block:: javascript
-
-    Symfony({
-      stimulus: 'assets/controllers.json',
-    })
-    // or, to override the local controllers dir:
-    Symfony({
-      stimulus: {
-        controllersJson: 'assets/controllers.json',
-        controllersDir: 'assets/controllers',
-      },
-    })
-
-Then start the app from your entry:
-
-.. code-block:: javascript
-
-    import { startStimulusApp } from '@symfony/reprise/stimulus'
-
-    const app = startStimulusApp()
-
-**Local controllers.** Any ``assets/controllers/*_controller.{js,ts}`` is registered automatically. The filename
-becomes the identifier (``hello_controller.js`` becomes ``hello``, ``admin/user_controller.js`` becomes
-``admin--user``). To load a controller on demand, put a ``stimulusFetch: 'lazy'`` comment directly above the
-class; a block or a single-line comment both work.
-
-.. code-block:: javascript
-
-    import { Controller } from '@hotwired/stimulus'
-
-    /* stimulusFetch: 'lazy' */
-    export default class extends Controller {}
-
-(``// stimulusFetch: 'lazy'`` on the line above the class works too, as does a preserved
-``/*! stimulusFetch: 'lazy' */`` comment: the form tsc and esbuild keep through minification.)
-
-**Third-party UX packages.** Controllers declared in ``controllers.json`` are resolved from ``node_modules``, so
-install them with your package manager, the same as you would with Webpack Encore. For example, with Stimulus and
-UX Leaflet Map:
-
-.. code-block:: terminal
-
-    $ npm install @hotwired/stimulus @symfony/ux-leaflet-map
-
-Some packages need a bit of bundler-specific setup on top, the same way they did under Webpack Encore. UX Leaflet
-Map, for instance, ships a CSS file meant for Webpack's loader and needs an alias to the plain CSS build:
-
-.. code-block:: javascript
-
-    // vite.config.ts
-    export default defineConfig({
-      resolve: {
-        alias: {
-          'leaflet/dist/leaflet.min.css': 'leaflet/dist/leaflet.css',
-        },
-      },
-    })
-
-Check each package's own docs for this kind of tweak.
-
-File copy
----------
-
-Some assets aren't imported from JavaScript or CSS at all: they're referenced by a stable path straight from your
-templates, like ``{{ asset('build/images/logo.svg') }}``. Point ``copy`` at the directories that hold them and
-Reprise copies each file into the build and records it in ``manifest.json``. Once Symfony is pointed at that
-manifest (below), the ``asset()`` helper resolves the logical path to the hashed URL:
-
-.. code-block:: javascript
-
-    // vite.config.ts
-    import { defineConfig } from 'vite'
-    import Symfony from '@symfony/reprise/vite'
-
-    export default defineConfig({
-      plugins: [
-        Symfony({
-          copy: [
-            {
-              from: 'assets/images',
-              to: 'images',
-            },
-          ],
-        }),
-      ],
-    })
-
-.. code-block:: javascript
-
-    // rsbuild.config.ts
-    import { defineConfig } from '@rsbuild/core'
-    import Symfony from '@symfony/reprise/rsbuild'
-
-    export default defineConfig({
-      plugins: [
-        Symfony({
-          copy: [
-            {
-              from: 'assets/images',
-              to: 'images',
-            },
-          ],
-        }),
-      ],
-    })
-
-``from`` and ``to`` are both required: ``from`` is the source directory (relative to your project root), ``to`` is
-the destination prefix used for the manifest key. Restrict which files are copied with ``pattern``, a regular
-expression tested against each file's path relative to ``from`` (by default every file is copied).
-``includeSubdirectories`` defaults to ``true``; set it to ``false`` to turn off recursion.
-
-How copied files are handled depends on the mode:
-
-- **Build**: each file gets a content hash in its filename for cache busting.
-- **Dev**: files are copied verbatim, no hash.
-
-Either way they land in ``public/build`` and are served by the Symfony web server, not the Vite/Rsbuild dev server,
-so they're available whether or not the dev server is running.
-
-For ``asset()`` to return the hashed URL, point Symfony's asset component at the generated ``manifest.json`` with
-``framework.assets.json_manifest_path``:
-
-.. code-block:: yaml
-
-    # config/packages/framework.yaml
-    framework:
-        assets:
-            json_manifest_path: '%kernel.project_dir%/public/build/manifest.json'
-
-This is Symfony's native manifest support, the same setting Webpack Encore relies on, so it applies to every logical
-asset reference, not just copied files. The entry references that ``RepriseBundle`` renders already carry their hash
-and aren't manifest keys, so they pass through untouched.
-
-By default the lookup is lenient: a reference missing from the manifest is returned unchanged. Set
-``framework.assets.strict_mode: true`` to fail loudly on an unknown reference instead. Under strict mode, the entry
-references ``RepriseBundle`` renders would be rejected too, so route them through a package that skips the manifest:
-set ``reprise.asset_package`` to a package with ``version: false`` (see `Configuration`_) and keep
-``json_manifest_path`` on the default package for your other assets.
-
-Using a CDN
------------
-
-To serve your built assets from a CDN, set ``publicPath`` to the absolute CDN URL, for the production build only. In
-dev, the dev server serves assets directly, so keep the local ``/build/`` path there. Both bundlers expose the mode
-through the function form of their config, so switch on ``command === 'build'``:
-
-.. code-block:: javascript
-
-    // vite.config.ts  (command is 'serve' or 'build')
-    import { defineConfig } from 'vite'
-    import Symfony from '@symfony/reprise/vite'
-
-    export default defineConfig(({ command }) => ({
-      plugins: [
-        Symfony({
-          publicPath:
-            command === 'build'
-              ? 'https://my-cool-app.com.global.prod.fastly.net/build/'
-              : '/build/',
-          manifestKeyPrefix: 'build/',
-        }),
-      ],
-    }))
-
-.. code-block:: javascript
-
-    // rsbuild.config.ts  (command is 'dev' or 'build')
-    import { defineConfig } from '@rsbuild/core'
-    import Symfony from '@symfony/reprise/rsbuild'
-
-    export default defineConfig(({ command }) => ({
-      plugins: [
-        Symfony({
-          publicPath:
-            command === 'build'
-              ? 'https://my-cool-app.com.global.prod.fastly.net/build/'
-              : '/build/',
-          manifestKeyPrefix: 'build/',
-        }),
-      ],
-    }))
-
-With an absolute ``publicPath``, ``manifestKeyPrefix`` is **required**: Reprise has no way to guess the right prefix
-for the ``manifest.json`` keys, and throws a clear error if it's missing. Keys stay logical, values point at the
-CDN:
-
-.. code-block:: json
-
-    {
-      "build/app.js": "https://my-cool-app.com.global.prod.fastly.net/build/app-1a2b3c.js"
-    }
-
-``entrypoints.json`` is rewritten the same way, so the ``<script>`` and ``<link>`` tags render with CDN URLs. You
-still have to upload the built files to the CDN yourself, or set up origin pull. For a CDN subdirectory, include it
-in the URL (``https://my-cool-app.com.global.prod.fastly.net/awesome-website/build/``).
-
-Subresource Integrity
----------------------
-
-When enabled, Reprise adds an ``integrity`` map to ``entrypoints.json`` (asset URL -> SRI hash). ``RepriseBundle``
-reads that map and renders ``integrity="..."`` on the generated ``<script>`` and ``<link>`` tags, so the browser
-refuses any asset whose bytes were tampered with.
-
-The ``integrity`` option takes an object ``{ enabled, algorithms? }``. It only makes sense for the production build:
-the dev server serves changing in-memory assets, so no hashes are emitted in dev. As with the CDN example, toggle it
-with ``command === 'build'``:
-
-.. code-block:: javascript
-
-    // vite.config.ts  (command is 'serve' or 'build')
-    import { defineConfig } from 'vite'
-    import Symfony from '@symfony/reprise/vite'
-
-    export default defineConfig(({ command }) => ({
-      plugins: [
-        Symfony({
-          integrity: {
-            enabled: command === 'build',
-            algorithms: ['sha384'],
-          },
-        }),
-      ],
-    }))
-
-.. code-block:: javascript
-
-    // rsbuild.config.ts  (command is 'dev' or 'build')
-    import { defineConfig } from '@rsbuild/core'
-    import Symfony from '@symfony/reprise/rsbuild'
-
-    export default defineConfig(({ command }) => ({
-      plugins: [
-        Symfony({
-          integrity: {
-            enabled: command === 'build',
-            algorithms: ['sha384'],
-          },
-        }),
-      ],
-    }))
-
-``algorithms`` is optional and defaults to ``['sha384']``. Accepted values are ``'sha256'``, ``'sha384'`` and
-``'sha512'``. Passing several (e.g. ``['sha256', 'sha512']``) writes multiple space-separated hashes per file, which
-the browser treats as "any one of these must match".
-
-The resulting ``entrypoints.json`` gets an extra ``integrity`` section:
-
-.. code-block:: json
-
-    {
-      "integrity": {
-        "/build/app-1a2b3c.js": "sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K...",
-        "/build/app-4d5e6f.css": "sha384-9ehJ4G8v3aQ2p1o0..."
-      }
-    }
-
-Hashes cover every referenced file in each entry (js, css, and preloaded/dynamic chunks), and since they're computed
-from the files actually written to disk, they stay correct through minification and hashing.
 
 .. _Vite: https://vite.dev/
 .. _Rsbuild: https://rsbuild.dev/


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Reorganizes `doc/index.rst` for a clearer reading order. No content changes.

- Vite and Rsbuild plugin setup now nest under **Installation** instead of sitting as separate top-level sections.
- The optional features (Symfony UX / Stimulus, file copy, CDN, Subresource Integrity) move under a new **Features** section.
- **Configuration** moves to the end, where it reads as a reference.
- **Rendering asset tags** stays top-level as the core usage step.

Only heading levels and section order change; the prose and examples are untouched.
