### PR TITLE
[Rsbuild] Fix binary assets corrupted since #27

### DIFF
--- a/assets/src/index.ts
+++ b/assets/src/index.ts
@@ -33,6 +33,12 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, _
         // Shared Stimulus virtual module: unplugin applies these universal hooks to Vite and forwards
         // them to Rspack (via `api.modifyRspackConfig`), so one implementation serves both bundlers. The
         // `\0` prefix sidesteps Rspack's URI-scheme rejection of a raw `virtual:` id.
+        //
+        // On Rspack, unplugin attaches its `load` loader to every module whose `loadInclude` passes
+        // (and retypes it `javascript/auto`). Without this gate it would match binary assets too —
+        // the loader is not `raw`, so it re-emits them as UTF-8 strings and corrupts images/fonts in
+        // dev. Restrict it to the virtual id so real files are never touched.
+        loadInclude: (id) => id.includes(VIRTUAL_ID),
         resolveId(id) {
             if (id !== VIRTUAL_ID) return;
             // Imported unconditionally by `startStimulusApp()`; fail clearly when the feature is off.

--- a/assets/test/integration/binary-asset-integrity.test.ts
+++ b/assets/test/integration/binary-asset-integrity.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, readdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRsbuild } from '@rsbuild/core';
+import { build } from 'vite';
+import { describe, expect, it } from 'vitest';
+import SymfonyRsbuild from '../../src/rsbuild';
+import SymfonyVite from '../../src/vite';
+
+// A binary asset must be emitted byte-for-byte. On Rspack, unplugin's `load` loader (injected via
+// createRsbuildPlugin for the Stimulus virtual module) attaches to every module unless gated by
+// `loadInclude`; being non-`raw`, it re-emits binary as a UTF-8 string and corrupts it (bytes
+// >0x7F -> U+FFFD, ~2x size). Guard both bundlers against re-encoding an imported image.
+const fixture = join(import.meta.dirname, '../fixtures/imported-asset');
+const source = readFileSync(join(fixture, 'media/pic.png'));
+
+function emittedPng(out: string): Buffer {
+    const pngs = readdirSync(out, { recursive: true })
+        .map(String)
+        .filter((f) => /\.png$/.test(f));
+    expect(pngs).toHaveLength(1);
+    return readFileSync(join(out, pngs[0]));
+}
+
+describe('binary assets are emitted intact (Vite/Rsbuild parity)', () => {
+    it('vite emits the imported image byte-for-byte', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-bin-vite-'));
+        await build({
+            root: fixture,
+            logLevel: 'silent',
+            build: {
+                emptyOutDir: true,
+                assetsInlineLimit: 0,
+                rollupOptions: { input: { app: join(fixture, 'app.js') } },
+            },
+            plugins: [SymfonyVite({ outputPath: out, publicPath: '/build/' })],
+        });
+
+        expect(emittedPng(out).equals(source)).toBe(true);
+    }, 30_000);
+
+    it('rsbuild emits the imported image byte-for-byte', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-bin-rsbuild-'));
+        const rsbuild = await createRsbuild({
+            cwd: fixture,
+            rsbuildConfig: {
+                mode: 'production',
+                source: { entry: { app: join(fixture, 'app.js') } },
+                output: { dataUriLimit: 0 },
+                plugins: [SymfonyRsbuild({ outputPath: out, publicPath: '/build/' })],
+            },
+        });
+        await rsbuild.build();
+
+        expect(emittedPng(out).equals(source)).toBe(true);
+    }, 60_000);
+});


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

Binary assets (images, fonts) referenced from CSS `url()` or imported from JS come out corrupted under Rsbuild, in both `rsbuild dev` and `rsbuild build`. The served/emitted file ends up roughly twice its original size and is no longer a valid image. Vite is unaffected.

Concretely, a WebP that starts with the bytes `52 49 46 46 d8 17 ...` ("RIFF") is served as `52 49 46 46 ef bf bd 17 ...`: every byte greater than `0x7F` has been replaced by `ef bf bd`, the UTF-8 encoding of U+FFFD (the replacement character). That's the signature of binary data being read as a UTF-8 string and re-encoded.

The Rsbuild adapter goes through unplugin's `createRsbuildPlugin`. Because the plugin defines a universal `load` hook (used to serve the Stimulus `virtual:symfony/controllers` module), unplugin injects its load loader into the Rspack config. With no `loadInclude` filter, the loader's rule matches every module and additionally forces `type: "javascript/auto"` on it. That loader isn't declared `raw`, so Rspack hands it each module's bytes already decoded as a UTF-8 string; for a binary asset this mangles it before it's ever emitted. This is a regression from #27, which migrated the Rsbuild path from a hand-written native plugin to `createRsbuildPlugin`: the old native plugin never attached such a loader.

Fix is a `loadInclude` filter so unplugin only attaches its load loader to the Stimulus virtual module id, never to real files: `loadInclude: (id) => id.includes(VIRTUAL_ID)`. It applies to both bundlers via the shared unplugin factory; on Rspack it's what stops the loader from touching binary assets.

Added an integration test (both Vite and Rsbuild, per the project's bundler-parity rule) asserting that an imported binary asset is emitted byte-for-byte identical to its source. Confirmed it fails on the Rsbuild side without the fix and passes with it.

No CHANGELOG entry: the unplugin-based Rsbuild support (0.2.0) isn't released yet, so this regression never shipped. It's fixed within the same unreleased line.
