### PR TITLE
[TypeScript] Type-check the sources and run tsc in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
               run: pnpm run lint
             - name: Format check
               run: pnpm run fmt:check
+            - name: Typecheck
+              run: pnpm run typecheck
 
     test:
         name: Node ${{ matrix.node-version }} on ${{ matrix.os }}

--- a/assets/package.json
+++ b/assets/package.json
@@ -52,6 +52,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown -w",
+    "typecheck": "tsc -p tsconfig.typecheck.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "prepublishOnly": "tsdown"

--- a/assets/src/index.ts
+++ b/assets/src/index.ts
@@ -191,7 +191,9 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, _
                     // binds `::1` only, so a literal `127.0.0.1` isn't listening and refuses HMR/lazy/chunk requests.
                     // Same `0.0.0.0`/unset -> `localhost` mapping as the `done` tap, so client + origin stay in sync.
                     const devHost =
-                        config.server.host && config.server.host !== '0.0.0.0' ? config.server.host : 'localhost';
+                        typeof config.server.host === 'string' && config.server.host !== '0.0.0.0'
+                            ? config.server.host
+                            : 'localhost';
 
                     // Pin the HMR/lazy-compilation client to the dev server: by default it derives its WS URL from
                     // `window.location` (the Symfony page) and 404s. `<port>` is substituted at server start; the
@@ -216,7 +218,8 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, _
                         ...prevList,
                         (rspackConfig) => {
                             rspackConfig.experiments ??= {};
-                            rspackConfig.experiments.outputModule = true;
+                            // `outputModule` is a valid Rspack experiment but missing from its typings.
+                            (rspackConfig.experiments as { outputModule?: boolean }).outputModule = true;
                             rspackConfig.output ??= {};
                             rspackConfig.output.module = true;
                             rspackConfig.output.chunkFormat = 'module';

--- a/assets/tsconfig.typecheck.json
+++ b/assets/tsconfig.typecheck.json
@@ -1,0 +1,12 @@
+{
+    // Type-check only (`tsc --noEmit`); tsdown owns the real build. Relative imports are extensionless
+    // because every consumer (tsdown, Vite, Rspack) resolves them bundler-style, so type-check the same
+    // way instead of the base config's `nodenext`. `stimulus.ts` is browser code, hence the DOM libs.
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "module": "preserve",
+        "moduleResolution": "bundler",
+        "lib": ["es2024", "esnext.array", "esnext.collection", "es2025.iterator", "dom", "dom.iterable"],
+        "noEmit": true
+    }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "pnpm -C assets run build",
     "dev": "pnpm -C assets run dev",
+    "typecheck": "pnpm -C assets run typecheck",
     "test": "pnpm -C assets run test",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

The TypeScript sources were never type-checked. `tsdown` (rolldown/oxc) transpiles without checking types, and CI only ran lint, format, build and tests, so type errors could ship silently despite the project claiming "strict TypeScript". This PR adds a dedicated `assets/tsconfig.typecheck.json`, a `typecheck` script in `assets` and at the root, and a Typecheck step in the CI `lint` job.

## Why a separate tsconfig

The base `tsconfig.json` extends `@tsconfig/node22`, whose `nodenext` resolution expects `.js` extensions on relative imports. The sources are written extensionless, since every consumer (tsdown, Vite, Rspack) resolves them bundler-style. The typecheck config uses `moduleResolution: bundler` instead, matching the resolution the code is actually built with, and adds the DOM libs since `stimulus.ts` is browser code. The build `tsconfig.json` is untouched, so there's zero risk to the tsdown build.

## Type errors found and fixed

Turning the check on surfaced two real type errors:

- In the Rsbuild setup, `devHost` could be `string | true` (when `server.host` is `true`) and then get interpolated into a URL. It's now guarded with `typeof ... === 'string'`, falling back to `localhost`.
- `experiments.outputModule` is a valid Rspack experiment but is missing from the `@rspack/core` `Experiments` typings, so it's set through a narrow cast.
