### PR TITLE
[Options] Treat a protocol-relative publicPath as absolute

### DIFF
--- a/assets/src/core/options.ts
+++ b/assets/src/core/options.ts
@@ -1,6 +1,15 @@
 import type { CopyEntry, Options, ResolvedCopyEntry, ResolvedOptions, ResolvedStimulusOptions } from '../types';
 import * as path from 'node:path';
 
+/**
+ * Whether `publicPath` points off the docroot: an absolute URL (`https://cdn/…`) or a
+ * protocol-relative one (`//cdn/…`). Both need an explicit `manifestKeyPrefix` and must never
+ * get the dev-server origin prepended.
+ */
+export function isAbsolutePublicPath(publicPath: string): boolean {
+    return publicPath.includes('://') || publicPath.startsWith('//');
+}
+
 function normalizeIntegrity(integrity: Options['integrity']): ResolvedOptions['integrity'] {
     if (!integrity?.enabled) return undefined;
     return { algorithms: integrity.algorithms?.length ? [...integrity.algorithms] : ['sha384'] };
@@ -48,7 +57,7 @@ export function normalizeOptions(options: Options | undefined, cwd: string): Res
 
     let manifestKeyPrefix = options?.manifestKeyPrefix ?? null;
     if (manifestKeyPrefix === null) {
-        if (publicPath.includes('://')) {
+        if (isAbsolutePublicPath(publicPath)) {
             throw new Error(
                 `@symfony/reprise: cannot derive "manifestKeyPrefix" from an absolute "publicPath" (${publicPath}). ` +
                     'Set "manifestKeyPrefix" explicitly (e.g. "build/").'
@@ -69,6 +78,6 @@ export function normalizeOptions(options: Options | undefined, cwd: string): Res
 }
 
 export function resolvePublicPath(publicPath: string, devOrigin: string | null): string {
-    if (!devOrigin || publicPath.includes('://')) return publicPath;
+    if (!devOrigin || isAbsolutePublicPath(publicPath)) return publicPath;
     return `${devOrigin.replace(/\/$/, '')}${publicPath}`;
 }

--- a/assets/src/index.ts
+++ b/assets/src/index.ts
@@ -12,7 +12,7 @@ import { resolveDevOrigin } from './core/dev-server';
 import { writeSymfonyFiles } from './core/emit';
 import { buildEntrypoints, buildManifest, joinUrl } from './core/format';
 import { integrityFromDisk, referencedFileNames } from './core/integrity';
-import { normalizeOptions, resolvePublicPath } from './core/options';
+import { isAbsolutePublicPath, normalizeOptions, resolvePublicPath } from './core/options';
 import { generateControllersModule, STIMULUS_NOT_ENABLED_MESSAGE, VIRTUAL_CONTROLLERS_ID } from './core/stimulus';
 
 const VIRTUAL_ID = VIRTUAL_CONTROLLERS_ID;
@@ -180,7 +180,7 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, _
                     config.server.publicDir = false;
                     // Serve the dev server under `publicPath` so advertised URLs match (else every URL 404s).
                     // `server.base` must be a slash-path, so an absolute (CDN) publicPath falls back to `/`.
-                    config.server.base = resolved.publicPath.includes('://') ? '/' : resolved.publicPath;
+                    config.server.base = isAbsolutePublicPath(resolved.publicPath) ? '/' : resolved.publicPath;
                     // Already defaulted to `/` by Rsbuild, so `??=` wouldn't apply — assign unconditionally.
                     // Drives production asset URLs (dev uses `server.base` above).
                     config.output.assetPrefix = resolved.publicPath;
@@ -205,7 +205,7 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, _
                     };
                     // Async chunk URLs come from `dev.assetPrefix` (default `/` -> 404 against the Symfony page).
                     // It's used verbatim (no `server.base` composed in), so carry the full publicPath; skip CDN.
-                    if (!resolved.publicPath.includes('://')) {
+                    if (!isAbsolutePublicPath(resolved.publicPath)) {
                         config.dev.assetPrefix = `${config.server.https ? 'https' : 'http'}://${devHost}:<port>${resolved.publicPath}`;
                     }
 

--- a/assets/test/core/options.test.ts
+++ b/assets/test/core/options.test.ts
@@ -47,6 +47,16 @@ describe('normalizeOptions', () => {
         expect(r.manifestKeyPrefix).toBe('build/');
     });
 
+    it('throws for a protocol-relative publicPath without manifestKeyPrefix', () => {
+        expect(() => normalizeOptions({ publicPath: '//cdn.example.com/x' }, '/app')).toThrow(/manifestKeyPrefix/);
+    });
+
+    it('accepts a protocol-relative publicPath when manifestKeyPrefix is set', () => {
+        const r = normalizeOptions({ publicPath: '//cdn.example.com/x', manifestKeyPrefix: 'build/' }, '/app');
+        expect(r.publicPath).toBe('//cdn.example.com/x');
+        expect(r.manifestKeyPrefix).toBe('build/');
+    });
+
     it('leaves stimulus undefined when not configured', () => {
         const r = normalizeOptions(undefined, '/app');
         expect(r.stimulus).toBeUndefined();
@@ -149,5 +159,8 @@ describe('resolvePublicPath', () => {
         expect(resolvePublicPath('https://cdn.example.com/x/', 'http://127.0.0.1:5173')).toBe(
             'https://cdn.example.com/x/'
         );
+    });
+    it('keeps a protocol-relative publicPath as-is even in dev', () => {
+        expect(resolvePublicPath('//cdn.example.com/x/', 'http://127.0.0.1:5173')).toBe('//cdn.example.com/x/');
     });
 });


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

A protocol-relative `publicPath` such as `//cdn.example.com/build/` slipped past the `publicPath.includes('://')` check used to classify a `publicPath` as absolute. As a result it got a bogus derived `manifestKeyPrefix` (only the first leading slash stripped) and, in dev, the dev-server origin prepended to it, breaking the URL.

This PR adds a shared `isAbsolutePublicPath` helper (absolute `https://` or protocol-relative `//`) and uses it in the `manifestKeyPrefix` guard, in `resolvePublicPath`, and in the two Rsbuild checks in `index.ts`, so protocol-relative and absolute URLs are treated identically. Like an absolute CDN URL, a protocol-relative one now requires an explicit `manifestKeyPrefix`.

Adds unit tests for the guard and for `resolvePublicPath`.
