### PR TITLE
[Package] Expose per-entry types through the exports map

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -25,24 +25,31 @@
     "encore"
   ],
   "exports": {
-    ".": "./dist/index.mjs",
-    "./rsbuild": "./dist/rsbuild.mjs",
-    "./stimulus": "./dist/stimulus.mjs",
-    "./types": "./dist/types.mjs",
-    "./vite": "./dist/vite.mjs",
+    ".": {
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    },
+    "./rsbuild": {
+      "types": "./dist/rsbuild.d.mts",
+      "default": "./dist/rsbuild.mjs"
+    },
+    "./stimulus": {
+      "types": "./dist/stimulus.d.mts",
+      "default": "./dist/stimulus.mjs"
+    },
+    "./types": {
+      "types": "./dist/types.d.mts",
+      "default": "./dist/types.mjs"
+    },
+    "./vite": {
+      "types": "./dist/vite.d.mts",
+      "default": "./dist/vite.mjs"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/*",
-        "./*"
-      ]
-    }
-  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

`@symfony/reprise` exposed its type declarations through a `typesVersions` wildcard plus bare-string `exports` entries. This PR gives each `exports` entry explicit `types` and `default` conditions, the mechanism `node16`/`nodenext`/`bundler` module resolution actually reads, and drops the `typesVersions` hack.

All five subpath entries (`.`, `./rsbuild`, `./stimulus`, `./types`, `./vite`) now resolve to their generated `.d.mts`. The top-level `types` field is kept as a fallback.
