### PR TITLE
[Vite] Collect entry CSS from facade chunks

### DIFF
--- a/assets/src/collectors/vite.ts
+++ b/assets/src/collectors/vite.ts
@@ -18,8 +18,11 @@ export function bundleToGraph(bundle: Rollup.OutputBundle, root: string): Normal
     for (const file of Object.values(bundle)) {
         if (file.type !== 'chunk') continue;
         const chunk = file as ViteOutputChunk;
-        const css = chunk.viteMetadata ? [...chunk.viteMetadata.importedCss] : [];
         if (chunk.isEntry) {
+            // Rollup can emit the entry as a thin *facade* that just re-imports the real chunk (e.g. when the
+            // entry module uses top-level await); the CSS then rides on that statically-imported chunk, not the
+            // facade. Walk static imports so entry CSS is collected wherever Rollup parked it.
+            const css = collectEntryCss(chunk, bundle);
             for (const name of css) entryCss.add(name);
             entryPoints[chunk.name] = {
                 js: [chunk.fileName],
@@ -28,8 +31,8 @@ export function bundleToGraph(bundle: Rollup.OutputBundle, root: string): Normal
                 dynamic: [...chunk.dynamicImports],
             };
             assets.push({ logicalName: `${chunk.name}.js`, fileName: chunk.fileName });
-        } else {
-            for (const name of css) asyncCss.add(name);
+        } else if (chunk.viteMetadata) {
+            for (const name of chunk.viteMetadata.importedCss) asyncCss.add(name);
         }
     }
 
@@ -41,6 +44,26 @@ export function bundleToGraph(bundle: Rollup.OutputBundle, root: string): Normal
     }
 
     return { entryPoints, assets };
+}
+
+// Collect an entry's CSS: its own `importedCss` plus that of every statically-imported chunk, reached
+// transitively. Static imports only — dynamic-import CSS loads with its chunk and stays out of the entry.
+function collectEntryCss(entry: ViteOutputChunk, bundle: Rollup.OutputBundle): string[] {
+    const css = new Set<string>();
+    const visited = new Set<string>();
+    const walk = (chunk: ViteOutputChunk): void => {
+        if (chunk.viteMetadata) {
+            for (const name of chunk.viteMetadata.importedCss) css.add(name);
+        }
+        for (const imported of chunk.imports) {
+            if (visited.has(imported)) continue;
+            visited.add(imported);
+            const dep = bundle[imported];
+            if (dep && dep.type === 'chunk') walk(dep as ViteOutputChunk);
+        }
+    };
+    walk(entry);
+    return [...css];
 }
 
 function assetLogicalName(file: Rollup.OutputAsset, root: string, entryCss: Set<string>): string {

--- a/assets/test/collectors/vite.test.ts
+++ b/assets/test/collectors/vite.test.ts
@@ -45,6 +45,66 @@ describe('bundleToGraph', () => {
         expect(graph.entryPoints.vendor).toBeUndefined();
     });
 
+    it('collects entry CSS from a facade chunk that only re-imports the real chunk', () => {
+        // Rollup emits a thin *facade* entry (e.g. when the entry uses top-level await) that just re-imports
+        // the real chunk; the CSS then rides on that statically-imported chunk, not the facade itself.
+        const bundle = {
+            'app-facade.js': {
+                ...chunk({
+                    fileName: 'app-facade.js',
+                    name: 'app',
+                    isEntry: true,
+                    imports: ['app-real.js'],
+                }),
+                viteMetadata: { importedCss: new Set<string>(), importedAssets: new Set() },
+            },
+            'app-real.js': {
+                ...chunk({ fileName: 'app-real.js', name: 'app', isEntry: false }),
+                viteMetadata: { importedCss: new Set(['app-c3.css']), importedAssets: new Set() },
+            },
+            'app-c3.css': asset('app-c3.css', ['app.css']),
+        } as unknown as Rollup.OutputBundle;
+
+        const graph = bundleToGraph(bundle, '/app');
+
+        expect(graph.entryPoints.app).toEqual({
+            js: ['app-facade.js'],
+            css: ['app-c3.css'],
+            preload: ['app-real.js'],
+            dynamic: [],
+        });
+        // The facade's CSS must stay in the manifest (keyed by name), not be dropped as async chunk CSS.
+        expect(graph.assets).toContainEqual({ logicalName: 'app.css', fileName: 'app-c3.css' });
+    });
+
+    it('collects entry CSS transitively through a chain of statically imported chunks', () => {
+        // entry -> mid -> leaf, with CSS on both the mid and the (deepest) leaf chunk. The walk must
+        // follow imports to any depth, not just the entry's direct imports.
+        const bundle = {
+            'app.js': {
+                ...chunk({ fileName: 'app.js', name: 'app', isEntry: true, imports: ['mid.js'] }),
+                viteMetadata: { importedCss: new Set<string>(), importedAssets: new Set() },
+            },
+            'mid.js': {
+                ...chunk({ fileName: 'mid.js', name: 'mid', isEntry: false, imports: ['leaf.js'] }),
+                viteMetadata: { importedCss: new Set(['mid.css']), importedAssets: new Set() },
+            },
+            'leaf.js': {
+                ...chunk({ fileName: 'leaf.js', name: 'leaf', isEntry: false }),
+                viteMetadata: { importedCss: new Set(['leaf.css']), importedAssets: new Set() },
+            },
+            'mid.css': asset('mid.css', ['mid.css']),
+            'leaf.css': asset('leaf.css', ['leaf.css']),
+        } as unknown as Rollup.OutputBundle;
+
+        const graph = bundleToGraph(bundle, '/app');
+
+        expect(graph.entryPoints.app.css).toEqual(['mid.css', 'leaf.css']);
+        // Both stay in the manifest (keyed by name), not dropped as async chunk CSS.
+        expect(graph.assets).toContainEqual({ logicalName: 'mid.css', fileName: 'mid.css' });
+        expect(graph.assets).toContainEqual({ logicalName: 'leaf.css', fileName: 'leaf.css' });
+    });
+
     it('collects manifest assets: entry chunks by "<name>.js" and assets by names[0] without a source path', () => {
         const bundle = {
             'app-a1b2.js': chunk({ fileName: 'app-a1b2.js', name: 'app', isEntry: true }),

--- a/assets/test/fixtures/facade-css/app.css
+++ b/assets/test/fixtures/facade-css/app.css
@@ -1,0 +1,1 @@
+.facade-css { color: red; }

--- a/assets/test/fixtures/facade-css/app.js
+++ b/assets/test/fixtures/facade-css/app.js
@@ -1,0 +1,9 @@
+import './app.css';
+
+// The top-level await, combined with this module being imported by another entry (other.js), makes
+// Rollup emit `app` as a thin *facade* chunk that only re-imports the real chunk; the CSS then rides
+// on that real chunk, not the facade. This reproduces the Encore -> Reprise migration bug where entry
+// CSS went missing from entrypoints.json/manifest.json.
+await import('./lazy.js');
+
+export const a = 1;

--- a/assets/test/fixtures/facade-css/lazy.js
+++ b/assets/test/fixtures/facade-css/lazy.js
@@ -1,0 +1,1 @@
+export const x = 1;

--- a/assets/test/fixtures/facade-css/other.js
+++ b/assets/test/fixtures/facade-css/other.js
@@ -1,0 +1,4 @@
+// Importing from app.js is what forces app to be split into a shared real chunk + facade entry.
+import { a } from './app.js';
+
+console.log(a);

--- a/assets/test/integration/facade-css.test.ts
+++ b/assets/test/integration/facade-css.test.ts
@@ -1,0 +1,59 @@
+import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRsbuild } from '@rsbuild/core';
+import { build } from 'vite';
+import { describe, expect, it } from 'vitest';
+import SymfonyRsbuild from '../../src/rsbuild';
+import SymfonyVite from '../../src/vite';
+
+// The `app` entry statically imports CSS but uses a top-level await and is imported by a second entry
+// (other.js). Rollup therefore emits `app` as a thin *facade* chunk that only re-imports the real chunk;
+// the CSS rides on that real chunk, not the facade. The collector must walk the facade's static imports
+// so the entry CSS still lands in entrypoints.json (`css`) and manifest.json (`build/app.css`). Rspack has
+// no facade split — it flattens every entry asset into the entrypoint — so Rsbuild gets this for free; the
+// test pins the parity. This reproduces the Encore -> Reprise migration bug where entry CSS went missing.
+const fixture = join(import.meta.dirname, '../fixtures/facade-css');
+const input = { app: join(fixture, 'app.js'), other: join(fixture, 'other.js') };
+
+describe('facade entry CSS is collected (Vite/Rsbuild parity)', () => {
+    it('vite collects the entry CSS off the facade chunk', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-facade-vite-'));
+        await build({
+            root: fixture,
+            logLevel: 'silent',
+            build: { emptyOutDir: true, rollupOptions: { input } },
+            plugins: [SymfonyVite({ outputPath: out, publicPath: '/build/' })],
+        });
+
+        const entrypoints = JSON.parse(readFileSync(join(out, 'entrypoints.json'), 'utf8'));
+        const css: string[] = entrypoints.entryPoints.app.css;
+        expect(css).toHaveLength(1);
+        expect(css[0]).toMatch(/\.css$/);
+        expect(existsSync(join(out, css[0].replace(/^build\//, '')))).toBe(true);
+
+        const manifest = JSON.parse(readFileSync(join(out, 'manifest.json'), 'utf8'));
+        expect(manifest['build/app.css']).toMatch(/\.css$/);
+    }, 30_000);
+
+    it('rsbuild collects the entry CSS natively', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-facade-rsbuild-'));
+        const rsbuild = await createRsbuild({
+            cwd: fixture,
+            rsbuildConfig: {
+                mode: 'production',
+                source: { entry: input },
+                plugins: [SymfonyRsbuild({ outputPath: out, publicPath: '/build/' })],
+            },
+        });
+        await rsbuild.build();
+
+        const entrypoints = JSON.parse(readFileSync(join(out, 'entrypoints.json'), 'utf8'));
+        const css: string[] = entrypoints.entryPoints.app.css;
+        expect(css).toHaveLength(1);
+        expect(css[0]).toMatch(/\.css$/);
+
+        const manifest = JSON.parse(readFileSync(join(out, 'manifest.json'), 'utf8'));
+        expect(manifest['build/app.css']).toMatch(/\.css$/);
+    }, 60_000);
+});


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | None (found while migrating a real app; explained below)
| License        | MIT

When migrating a real app from Webpack Encore to Reprise, I ran into a case where an entry's CSS silently disappeared after `vite build`: `entrypoints.json` had `"css": []` for the entry, `manifest.json` had no `build/<entry>.css` key, and the page rendered unstyled, even though the entry has a plain top-level `import './main.scss'`.

#### Root cause

It only happens when the entry module has a top-level `await` and is also imported by another entry. In that case Rollup emits the entry as a thin facade chunk whose whole body is `import "./<real>.js";`. The CSS the entry imports then rides on that statically-imported real chunk's `viteMetadata.importedCss`, not on the facade chunk itself. The Vite collector (`bundleToGraph`) only ever read the entry chunk's own `importedCss` and never followed `chunk.imports`, so the CSS got dropped from `entrypoints.json` and, separately, misclassified as async-chunk CSS and dropped from `manifest.json` too.

#### Fix

The collector now walks the entry's static imports transitively and unions each visited chunk's `importedCss`. Dynamic imports are left untouched: CSS pulled in through a dynamic import still stays out of the entry and loads with its own chunk, same as before.

#### Rsbuild / tests

Rsbuild isn't affected: Rspack/webpack flattens every entry asset (JS and CSS across all chunks) directly into the entrypoint's asset list, which the Rspack collector already reads as-is. There's no facade split to worry about there.

Added a collector unit test for the facade case, plus a real-build integration test with a new fixture that reproduces the facade and runs against both Vite and Rsbuild, to pin the parity between the two. Reverting the fix turns the Vite tests red while the Rsbuild test stays green.
