### PR TITLE
[Vite] Prefer rolldownOptions over deprecated rollupOptions

### DIFF
--- a/assets/src/collectors/vite.ts
+++ b/assets/src/collectors/vite.ts
@@ -79,8 +79,8 @@ const CSS_EXTS = new Set(['.css', '.scss', '.sass', '.less', '.styl', '.stylus',
 export interface DevConfig {
     root: string;
     build: {
-        rollupOptions?: { input?: Rollup.InputOption };
         rolldownOptions?: { input?: Rollup.InputOption };
+        rollupOptions?: { input?: Rollup.InputOption };
     };
 }
 
@@ -90,8 +90,9 @@ function slash(p: string): string {
 
 export function configToDevGraph(config: DevConfig): NormalizedGraph {
     const entryPoints: Record<string, EntryFiles> = {};
-    // Vite 8 (rolldown) exposes the input under either key.
-    const input = config.build.rollupOptions?.input ?? config.build.rolldownOptions?.input;
+    // rolldown-vite renamed `build.rollupOptions` to `build.rolldownOptions`; prefer the new key and
+    // fall back to the deprecated one so both current Vite and rolldown-vite keep working.
+    const input = config.build.rolldownOptions?.input ?? config.build.rollupOptions?.input;
     const entries: Record<string, string> =
         typeof input === 'object' && input !== null && !Array.isArray(input) ? (input as Record<string, string>) : {};
 

--- a/assets/test/collectors/vite.test.ts
+++ b/assets/test/collectors/vite.test.ts
@@ -222,11 +222,24 @@ describe('configToDevGraph', () => {
         expect(configToDevGraph({ root: '/app', build: { rollupOptions: {} } } as any).entryPoints).toEqual({});
     });
 
-    it('reads rolldownOptions.input when rollupOptions is absent (Vite 8)', () => {
+    it('reads rolldownOptions.input when rollupOptions is absent (rolldown-vite)', () => {
         const graph = configToDevGraph({
             root: '/app',
             build: { rolldownOptions: { input: { app: '/app/assets/app.js' } } },
         } as any);
         expect(graph.entryPoints.app).toEqual({ js: ['assets/app.js'], css: [], preload: [], dynamic: [] });
+    });
+
+    it('prefers rolldownOptions.input over the deprecated rollupOptions', () => {
+        const graph = configToDevGraph({
+            root: '/app',
+            build: {
+                rolldownOptions: { input: { app: '/app/assets/app.js' } },
+                rollupOptions: { input: { legacy: '/app/assets/legacy.js' } },
+            },
+        } as any);
+        expect(graph.entryPoints).toEqual({
+            app: { js: ['assets/app.js'], css: [], preload: [], dynamic: [] },
+        });
     });
 });

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -53,7 +53,8 @@ Vite
 
     export default defineConfig({
       build: {
-        rollupOptions: {
+        // On Vite 7 or older, use `rollupOptions` instead
+        rolldownOptions: {
           input: {
             app: './assets/app.js',
           },

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -8,7 +8,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   build: {
-    rollupOptions: {
+    rolldownOptions: {
       input: {
         app: resolve(__dirname, './assets/app.js'),
         admin: resolve(__dirname, './assets/admin.js'),


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | N/A
| License        | MIT

rolldown-vite (Vite 8) renamed the build entry config from `build.rollupOptions` to `build.rolldownOptions`; `rollupOptions` still works but is now deprecated.

`configToDevGraph` (used in dev mode to discover named entries from the resolved Vite config) already read both keys, but tried `rollupOptions` first. This flips the precedence to prefer `rolldownOptions` and fall back to `rollupOptions`, so Vite 7 and older keep working unchanged.

Also updated the Vite doc example and the playground config to use `rolldownOptions`, with a short comment pointing Vite 7 and older users to `rollupOptions` instead.

No behavior change for existing users: both keys were and still are read. This just steers new users toward the non-deprecated key.
