### PR TITLE
[Core] Add shared path/URL normalization helpers

### DIFF
--- a/assets/src/collectors/vite.ts
+++ b/assets/src/collectors/vite.ts
@@ -1,6 +1,7 @@
 import type { Rollup } from 'vite';
 import type { AssetEntry, EntryFiles, NormalizedGraph } from '../types';
 import { extname, relative, resolve } from 'node:path';
+import { slash } from '../core/paths';
 
 interface ViteChunkMetadata {
     importedCss: Set<string>;
@@ -82,10 +83,6 @@ export interface DevConfig {
         rolldownOptions?: { input?: Rollup.InputOption };
         rollupOptions?: { input?: Rollup.InputOption };
     };
-}
-
-function slash(p: string): string {
-    return p.replace(/\\/g, '/');
 }
 
 export function configToDevGraph(config: DevConfig): NormalizedGraph {

--- a/assets/src/core/dev-server.ts
+++ b/assets/src/core/dev-server.ts
@@ -1,4 +1,5 @@
 import type { AddressInfo } from 'node:net';
+import { trimTrailingSlash } from './paths';
 
 export interface DevOriginInput {
     /** Explicit override — our `devServerOrigin` option (mirrors Encore's `--public`). */
@@ -10,8 +11,8 @@ export interface DevOriginInput {
 }
 
 export function resolveDevOrigin(address: AddressInfo, input: DevOriginInput): string {
-    if (input.override) return input.override.replace(/\/$/, '');
-    if (input.serverOrigin) return input.serverOrigin.replace(/\/$/, '');
+    if (input.override) return trimTrailingSlash(input.override);
+    if (input.serverOrigin) return trimTrailingSlash(input.serverOrigin);
 
     const host = address.family === 'IPv6' ? `[${address.address}]` : address.address;
     return `${input.https ? 'https' : 'http'}://${host}:${address.port}`;

--- a/assets/src/core/options.ts
+++ b/assets/src/core/options.ts
@@ -1,5 +1,6 @@
 import type { CopyEntry, Options, ResolvedCopyEntry, ResolvedOptions, ResolvedStimulusOptions } from '../types';
 import * as path from 'node:path';
+import { slash, trimTrailingSlash } from './paths';
 
 /**
  * Whether `publicPath` points off the docroot: an absolute URL (`https://cdn/…`) or a
@@ -18,7 +19,7 @@ function normalizeIntegrity(integrity: Options['integrity']): ResolvedOptions['i
 function normalizeCopyTo(to: string): string {
     // Drop leading `./`|`/` and trailing `/`: they corrupt the manifest key and make Rollup reject
     // a relative-looking emitted fileName.
-    const normalized = path.posix.normalize(to.replace(/\\/g, '/'));
+    const normalized = path.posix.normalize(slash(to));
     return normalized
         .replace(/^\.?\/+/, '')
         .replace(/^\.$/, '')
@@ -79,5 +80,5 @@ export function normalizeOptions(options: Options | undefined, cwd: string): Res
 
 export function resolvePublicPath(publicPath: string, devOrigin: string | null): string {
     if (!devOrigin || isAbsolutePublicPath(publicPath)) return publicPath;
-    return `${devOrigin.replace(/\/$/, '')}${publicPath}`;
+    return `${trimTrailingSlash(devOrigin)}${publicPath}`;
 }

--- a/assets/src/core/paths.ts
+++ b/assets/src/core/paths.ts
@@ -1,0 +1,9 @@
+/** Normalize Windows backslash separators to forward slashes (portable URLs and ESM specifiers). */
+export function slash(p: string): string {
+    return p.replace(/\\/g, '/');
+}
+
+/** Drop a single trailing slash, e.g. when composing a dev-server origin with a public path. */
+export function trimTrailingSlash(s: string): string {
+    return s.replace(/\/$/, '');
+}

--- a/assets/src/core/stimulus.ts
+++ b/assets/src/core/stimulus.ts
@@ -2,6 +2,7 @@ import type { ResolvedStimulusOptions } from '../types';
 import { readdirSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
+import { slash } from './paths';
 
 interface UserControllerConfig {
     enabled?: boolean;
@@ -119,7 +120,7 @@ export function generateControllersModule(opts: ResolvedStimulusOptions, root: s
             identifier,
             fetch: LAZY_COMMENT_RE.test(readFileSync(abs, 'utf8')) ? 'lazy' : 'eager',
             // Forward slashes: a portable ESM specifier (a Windows backslash path isn't).
-            main: abs.replace(/\\/g, '/'),
+            main: slash(abs),
             autoimports: [],
         });
     }
@@ -186,7 +187,7 @@ function listLocalControllers(dir: string): string[] {
     }
     return (
         entries
-            .map((e) => String(e).replace(/\\/g, '/'))
+            .map((e) => slash(String(e)))
             .filter((e) => LOCAL_CONTROLLER_RE.test(e))
             // Sort so the module (and its content hash) is stable across FS order. See symfony/ux#3703.
             .sort()
@@ -194,6 +195,6 @@ function listLocalControllers(dir: string): string[] {
 }
 
 function localIdentifier(rel: string): string {
-    const base = rel.replace(/\\/g, '/').replace(/[-_]controller\.[jt]s$/, '');
+    const base = slash(rel).replace(/[-_]controller\.[jt]s$/, '');
     return base.replace(/_/g, '-').replace(/\//g, '--');
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

Two tiny path/URL normalization one-liners were duplicated across modules. `p.replace(/\\/g, '/')` (backslash -> forward slash) showed up in the Vite collector, the Stimulus module, and the options normalizer; `s.replace(/\/$/, '')` (drop a trailing slash) showed up in the dev-server origin resolver and the public-path resolver.

This moves both into `core/paths.ts` as `slash()` and `trimTrailingSlash()` and reuses them at every call site.

I deliberately left `copy.ts`'s `.split(sep).join('/')` alone: it isn't equivalent to `slash()` on POSIX, where a filename can legally contain a literal backslash that `slash()` would corrupt.

No behavior change.
