### PR TITLE
[Asset] Track returned files in a set

### DIFF
--- a/src/Asset/EntrypointsLookup.php
+++ b/src/Asset/EntrypointsLookup.php
@@ -27,10 +27,10 @@ final class EntrypointsLookup implements EntrypointsLookupInterface
     private ?Entrypoints $entrypoints = null;
 
     /**
-     * Files already returned this request, so a chunk shared by several entries
-     * (e.g. a preloaded vendor chunk) is emitted only once per page.
+     * Files already returned this request, kept as a set (name => true) so a chunk shared by
+     * several entries (e.g. a preloaded vendor chunk) is emitted only once per page.
      *
-     * @var list<string>
+     * @var array<string, true>
      */
     private array $returnedFiles = [];
 
@@ -123,8 +123,15 @@ final class EntrypointsLookup implements EntrypointsLookupInterface
             'dynamic' => $entry->dynamic,
         };
 
-        $newFiles = array_values(array_diff($files, $this->returnedFiles));
-        $this->returnedFiles = [...$this->returnedFiles, ...$newFiles];
+        $newFiles = [];
+        foreach ($files as $file) {
+            if (!isset($this->returnedFiles[$file])) {
+                $newFiles[] = $file;
+            }
+        }
+        foreach ($newFiles as $file) {
+            $this->returnedFiles[$file] = true;
+        }
 
         return $newFiles;
     }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

`EntrypointsLookup` remembers the files it has already emitted this request so a chunk shared by several entries renders only once per page. It kept them in a list and, on every call, ran `array_diff` plus an array spread to append the new ones, which is O(n·m) and reallocates the whole list each time.

This tracks them in a set (`array<string, true>`) instead and dedups with `isset`. It marks entries only after building the new-files list, so the result is identical to `array_diff` even when the input itself contains duplicates.

This isn't a hot path at any realistic scale, so it's more of a shape/readability change than a performance one. No behavior change.
