### PR TITLE
[CI] Disable double-build on publish

### DIFF
--- a/.github/workflows/release-on-npm.yaml
+++ b/.github/workflows/release-on-npm.yaml
@@ -49,8 +49,5 @@ jobs:
             - name: Install root JS dependencies
               run: pnpm install --frozen-lockfile
 
-            - name: Build JS assets
-              run: pnpm run build
-
             - name: Publish on NPM
               run: pnpm publish --recursive --access public --no-git-checks --provenance


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update CHANGELOG.md file -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and CHANGELOG.md files -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

The file `assets/package.json` already contains `prebublishOnly` hook that runs `tsdown`

