### PR TITLE
[Asset] Reset asset state when an exception is handled

### DIFF
--- a/src/EventListener/ResetAssetsEventListener.php
+++ b/src/EventListener/ResetAssetsEventListener.php
@@ -12,13 +12,16 @@
 namespace Symfony\Reprise\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Reprise\Asset\EntrypointsLookupInterface;
+use Symfony\Reprise\Asset\TagRenderer;
 
 /**
- * Clears the lookup's per-request deduplication state once the main request finishes,
- * so a long-running worker (FrankenPHP, RoadRunner, ...) starts each request afresh.
+ * Clears the per-request asset state (lookup dedup + renderer client flag) once the main request finishes,
+ * so a long-running worker (FrankenPHP, RoadRunner, ...) starts afresh, and on an exception before
+ * ErrorListener renders the error page, so that page still gets the full tag set.
  *
  * @author Hugo Alliaume <hugo@alliau.me>
  *
@@ -28,14 +31,20 @@ final class ResetAssetsEventListener implements EventSubscriberInterface
 {
     public function __construct(
         private readonly EntrypointsLookupInterface $entrypointsLookup,
+        private readonly TagRenderer $tagRenderer,
     ) {
     }
 
     public function onFinishRequest(FinishRequestEvent $event): void
     {
         if ($event->isMainRequest()) {
-            $this->entrypointsLookup->reset();
+            $this->reset();
         }
+    }
+
+    public function onException(ExceptionEvent $event): void
+    {
+        $this->reset();
     }
 
     /**
@@ -43,6 +52,15 @@ final class ResetAssetsEventListener implements EventSubscriberInterface
      */
     public static function getSubscribedEvents(): array
     {
-        return [KernelEvents::FINISH_REQUEST => 'onFinishRequest'];
+        return [
+            KernelEvents::FINISH_REQUEST => 'onFinishRequest',
+            KernelEvents::EXCEPTION => 'onException',
+        ];
+    }
+
+    private function reset(): void
+    {
+        $this->entrypointsLookup->reset();
+        $this->tagRenderer->reset();
     }
 }

--- a/src/RepriseBundle.php
+++ b/src/RepriseBundle.php
@@ -103,7 +103,7 @@ final class RepriseBundle extends AbstractBundle
         $services->alias(EntrypointsLookupInterface::class, 'reprise.entrypoints_lookup');
 
         $services->set('reprise.reset_assets_listener', ResetAssetsEventListener::class)
-            ->args([service('reprise.entrypoints_lookup')])
+            ->args([service('reprise.entrypoints_lookup'), service('reprise.tag_renderer')])
             ->tag('kernel.event_subscriber')
         ;
 

--- a/tests/EventListener/ResetAssetsEventListenerTest.php
+++ b/tests/EventListener/ResetAssetsEventListenerTest.php
@@ -12,17 +12,30 @@
 namespace Symfony\Reprise\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\Asset\PathPackage;
+use Symfony\Component\Asset\VersionStrategy\EmptyVersionStrategy;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Reprise\Asset\EntrypointsLookup;
+use Symfony\Reprise\Asset\EntrypointsLookupInterface;
+use Symfony\Reprise\Asset\TagRenderer;
 use Symfony\Reprise\EventListener\ResetAssetsEventListener;
 
 final class ResetAssetsEventListenerTest extends TestCase
 {
-    private function lookup(): EntrypointsLookup
+    private function lookup(string $fixture = 'build'): EntrypointsLookup
     {
-        return new EntrypointsLookup(__DIR__.'/../fixtures/build/entrypoints.json');
+        return new EntrypointsLookup(__DIR__.'/../fixtures/'.$fixture.'/entrypoints.json');
+    }
+
+    private function rendererFor(EntrypointsLookupInterface $lookup): TagRenderer
+    {
+        return new TagRenderer($lookup, new Packages(new PathPackage('/', new EmptyVersionStrategy())));
     }
 
     private function finishRequest(int $requestType): FinishRequestEvent
@@ -30,25 +43,85 @@ final class ResetAssetsEventListenerTest extends TestCase
         return new FinishRequestEvent($this->createStub(HttpKernelInterface::class), Request::create('/'), $requestType);
     }
 
+    private function exceptionEvent(int $requestType): ExceptionEvent
+    {
+        return new ExceptionEvent($this->createStub(HttpKernelInterface::class), Request::create('/'), $requestType, new \RuntimeException('boom'));
+    }
+
     public function testResetsDeduplicationWhenTheMainRequestFinishes()
     {
         $lookup = $this->lookup();
         $lookup->getPreloadFiles('app'); // marks the shared chunk as already returned
 
-        new ResetAssetsEventListener($lookup)->onFinishRequest($this->finishRequest(HttpKernelInterface::MAIN_REQUEST));
+        new ResetAssetsEventListener($lookup, $this->rendererFor($lookup))->onFinishRequest($this->finishRequest(HttpKernelInterface::MAIN_REQUEST));
 
         // After the reset the shared chunk is offered again to the next request.
         $this->assertSame(['build/shared-e5f6.js'], $lookup->getPreloadFiles('admin'));
     }
 
-    public function testIgnoresSubRequests()
+    public function testIgnoresSubRequestsOnFinishRequest()
     {
         $lookup = $this->lookup();
         $lookup->getPreloadFiles('app');
 
-        new ResetAssetsEventListener($lookup)->onFinishRequest($this->finishRequest(HttpKernelInterface::SUB_REQUEST));
+        new ResetAssetsEventListener($lookup, $this->rendererFor($lookup))->onFinishRequest($this->finishRequest(HttpKernelInterface::SUB_REQUEST));
 
         // A sub-request finishing must NOT reset -- the shared chunk stays deduplicated.
         $this->assertSame([], $lookup->getPreloadFiles('admin'));
+    }
+
+    public function testResetsDeduplicationWhenAnExceptionIsHandled()
+    {
+        $lookup = $this->lookup();
+        $lookup->getPreloadFiles('app');
+
+        new ResetAssetsEventListener($lookup, $this->rendererFor($lookup))->onException($this->exceptionEvent(HttpKernelInterface::MAIN_REQUEST));
+
+        $this->assertSame(['build/shared-e5f6.js'], $lookup->getPreloadFiles('admin'));
+    }
+
+    public function testResetsDeduplicationEvenForSubRequestExceptions()
+    {
+        // An exception at any level abandons the render, so even a sub-request one resets (unlike FINISH_REQUEST).
+        $lookup = $this->lookup();
+        $lookup->getPreloadFiles('app');
+
+        new ResetAssetsEventListener($lookup, $this->rendererFor($lookup))->onException($this->exceptionEvent(HttpKernelInterface::SUB_REQUEST));
+
+        $this->assertSame(['build/shared-e5f6.js'], $lookup->getPreloadFiles('admin'));
+    }
+
+    public function testResetsTheRendererWhenAnExceptionIsHandled()
+    {
+        $lookup = $this->lookup('dev');
+        $renderer = $this->rendererFor($lookup);
+        $renderer->renderScriptTags('app');
+        $this->assertStringNotContainsString('@vite/client', $renderer->renderScriptTags('app'), 'sanity: not re-injected within the same request');
+
+        new ResetAssetsEventListener($lookup, $renderer)->onException($this->exceptionEvent(HttpKernelInterface::MAIN_REQUEST));
+
+        $this->assertStringContainsString('@vite/client', $renderer->renderScriptTags('app'));
+    }
+
+    public function testResetsBeforeTheErrorPageIsRendered()
+    {
+        $lookup = $this->lookup();
+        $renderer = $this->rendererFor($lookup);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new ResetAssetsEventListener($lookup, $renderer));
+
+        // Symfony's ErrorListener renders the error page at priority -128; capture what it would emit.
+        $errorPageTags = null;
+        $dispatcher->addListener(KernelEvents::EXCEPTION, static function () use (&$errorPageTags, $renderer) {
+            $errorPageTags = $renderer->renderScriptTags('app');
+        }, -128);
+
+        $full = $renderer->renderScriptTags('app');
+        $dispatcher->dispatch($this->exceptionEvent(HttpKernelInterface::MAIN_REQUEST), KernelEvents::EXCEPTION);
+
+        // Reprise's reset (default priority 0) runs before -128, so the error page gets the full tag set.
+        $this->assertSame($full, $errorPageTags);
+        $this->assertStringContainsString('build/app-a1b2.js', $errorPageTags);
     }
 }

--- a/tests/Functional/ExceptionResetTest.php
+++ b/tests/Functional/ExceptionResetTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Tests\Functional;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Reprise\Asset\TagRenderer;
+use Symfony\Reprise\EventListener\ResetAssetsEventListener;
+use Symfony\Reprise\Tests\Kernel\FunctionalAppKernel;
+
+final class ExceptionResetTest extends TestCase
+{
+    public function testTheErrorPageGetsTheFullTagsAfterAPartialRenderThrows()
+    {
+        $kernel = new FunctionalAppKernel(__DIR__.'/../fixtures/build');
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        /** @var TagRenderer $renderer */
+        $renderer = $container->get('reprise.tag_renderer');
+        /** @var ResetAssetsEventListener $listener */
+        $listener = $container->get('reprise.reset_assets_listener');
+
+        // Stand in for a controller that renders the entry, then throws.
+        $full = $renderer->renderScriptTags('app');
+        $this->assertStringContainsString('build/app-a1b2.js', $full);
+        $this->assertSame('', $renderer->renderScriptTags('app'), 'sanity: the deduplicated re-render is empty');
+
+        // The container-wired listener shares that lookup, so its reset clears the dedup set before the error page.
+        $listener->onException(new ExceptionEvent($kernel, Request::create('/'), HttpKernelInterface::MAIN_REQUEST, new \RuntimeException('boom')));
+
+        $this->assertSame($full, $renderer->renderScriptTags('app'));
+    }
+}

--- a/tests/Kernel/FunctionalAppKernel.php
+++ b/tests/Kernel/FunctionalAppKernel.php
@@ -74,6 +74,7 @@ final class FunctionalAppKernel extends Kernel implements CompilerPassInterface
     {
         $container->getAlias(EntrypointsLookupInterface::class)->setPublic(true);
         $container->getDefinition('reprise.tag_renderer')->setPublic(true);
+        $container->getDefinition('reprise.reset_assets_listener')->setPublic(true);
 
         if ($container->hasDefinition('reprise.entrypoints_cache_warmer')) {
             $container->getDefinition('reprise.entrypoints_cache_warmer')->setPublic(true);


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| License        | MIT

When a template renders an entry's tags and then throws, Symfony's `ErrorListener` renders the error page in a sub-request during `kernel.exception`. Until now RepriseBundle reset its per-request asset state (the entrypoints lookup's deduplication set and the tag renderer's "HMR client already injected" flag) only on `FINISH_REQUEST`, which fires *after* that error page has already been rendered. The result: the error page received only whatever deduplicated remainder of the tags was left over from the failed request, so `<script>` and `<link>` tags were missing, and in dev mode the HMR client was never injected.

The fix makes the reset listener also subscribe to `kernel.exception` at default priority (0), which runs ahead of `ErrorListener`'s -128. Both services are reset before `ErrorListener` takes over, so the error page gets the full tag set. This mirrors the approach taken by WebpackEncoreBundle's `ExceptionListener`. Covered by unit tests, including one that asserts the reset fires before the -128 error render, and a functional test for the full flow.
