### PR TITLE
[Twig] Add reprise_entry_exists()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.6.0
 
 - Add a per-call `attributes` argument to the `reprise_entry_script_tags()` and `reprise_entry_link_tags()` Twig functions
+- Add the `reprise_entry_exists()` Twig function
 
 ## 0.5.0
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -96,7 +96,7 @@ This is where Reprise pays off: once ``entrypoints.json`` exists, ``RepriseBundl
 ``<script>`` and ``<link>`` tags for an entry directly in Twig, the same experience `WebpackEncoreBundle`_ gives you
 with ``encore_entry_script_tags`` and ``encore_entry_link_tags``.
 
-Four Twig functions come with it:
+Five Twig functions come with it:
 
 .. code-block:: twig
 
@@ -124,6 +124,16 @@ Four Twig functions come with it:
 ``reprise_entry_js_files('app')`` and ``reprise_entry_css_files('app')`` are the same lookup, minus the HTML: they
 return the raw URL lists, for the rare case where you need the paths rather than the tags.
 
+``reprise_entry_exists('checkout')`` returns ``true`` when the named entry is present in ``entrypoints.json`` and
+``false`` otherwise. Use it to guard a page-specific or optional entry so rendering its tags doesn't error in strict
+mode:
+
+.. code-block:: twig
+
+    {% if reprise_entry_exists('checkout') %}
+        {{ reprise_entry_script_tags('checkout') }}
+    {% endif %}
+
 If you're migrating from Webpack Encore, it's a tag-for-tag swap (Reprise is Encore's heritage, so the template
 shape hasn't changed):
 
@@ -145,6 +155,9 @@ shape hasn't changed):
    * - ``encore_entry_js_files('app')``
      - ``reprise_entry_js_files('app')``
      - JS URL list
+   * - ``encore_entry_exists('app')``
+     - ``reprise_entry_exists('app')``
+     - ``true``/``false``
 
 ``reprise_entry_script_tags`` and ``reprise_entry_link_tags`` take a fourth ``attributes`` argument, merged over the
 global ``script_attributes``/``link_attributes`` (per-call wins, ``false`` drops the attribute). It mirrors Encore's

--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -119,6 +119,11 @@ final class TagRenderer implements ResetInterface
         return array_map(fn (string $r) => $this->url($r, $packageName), $this->lookup->getCssFiles($entryName));
     }
 
+    public function entryExists(string $entryName): bool
+    {
+        return $this->lookup->entryExists($entryName);
+    }
+
     public function reset(): void
     {
         $this->clientInjected = false;

--- a/src/Twig/AssetExtension.php
+++ b/src/Twig/AssetExtension.php
@@ -31,6 +31,7 @@ final class AssetExtension extends AbstractExtension
             new TwigFunction('reprise_entry_link_tags', [AssetRuntime::class, 'renderLinkTags'], ['is_safe' => ['html']]),
             new TwigFunction('reprise_entry_js_files', [AssetRuntime::class, 'getJsFiles']),
             new TwigFunction('reprise_entry_css_files', [AssetRuntime::class, 'getCssFiles']),
+            new TwigFunction('reprise_entry_exists', [AssetRuntime::class, 'entryExists']),
         ];
     }
 }

--- a/src/Twig/AssetRuntime.php
+++ b/src/Twig/AssetRuntime.php
@@ -63,4 +63,9 @@ final class AssetRuntime implements RuntimeExtensionInterface
     {
         return $this->tagRenderer->getCssFiles($entryName, $packageName);
     }
+
+    public function entryExists(string $entryName): bool
+    {
+        return $this->tagRenderer->entryExists($entryName);
+    }
 }

--- a/tests/Asset/TagRendererTest.php
+++ b/tests/Asset/TagRendererTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\WebLink\GenericLinkProvider;
 use Symfony\Reprise\Asset\DevServer;
+use Symfony\Reprise\Asset\EntrypointsLookup;
 use Symfony\Reprise\Asset\EntrypointsLookupInterface;
 use Symfony\Reprise\Asset\TagRenderer;
 
@@ -390,6 +391,17 @@ final class TagRendererTest extends TestCase
             .'<link rel="stylesheet" href="/build/b.css">',
             $html,
         );
+    }
+
+    public function testEntryExistsDelegatesToTheLookup()
+    {
+        $renderer = new TagRenderer(
+            new EntrypointsLookup(__DIR__.'/../fixtures/build/entrypoints.json'),
+            new Packages(new PathPackage('/', new EmptyVersionStrategy())),
+        );
+
+        $this->assertTrue($renderer->entryExists('app'));
+        $this->assertFalse($renderer->entryExists('does-not-exist'));
     }
 
     public function testModulepreloadHasNoIntegrityWhenTheChunkIsNotHashed()

--- a/tests/Twig/AssetExtensionTest.php
+++ b/tests/Twig/AssetExtensionTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Asset\Packages;
 use Symfony\Component\Asset\PathPackage;
 use Symfony\Component\Asset\VersionStrategy\EmptyVersionStrategy;
 use Symfony\Reprise\Asset\DevServer;
+use Symfony\Reprise\Asset\EntrypointsLookup;
 use Symfony\Reprise\Asset\EntrypointsLookupInterface;
 use Symfony\Reprise\Asset\TagRenderer;
 use Symfony\Reprise\Twig\AssetExtension;
@@ -87,6 +88,22 @@ final class AssetExtensionTest extends TestCase
             '<script src="/build/app.js" type="module" defer data-turbo-track="reload"></script>',
             $twig->render('page'),
         );
+    }
+
+    public function testEntryExistsFunctionReflectsTheLookup()
+    {
+        $twig = new Environment(new ArrayLoader([
+            'page' => "{{ reprise_entry_exists('app') ? 'yes' : 'no' }}|{{ reprise_entry_exists('missing') ? 'yes' : 'no' }}",
+        ]));
+        $twig->addExtension(new AssetExtension());
+        $twig->addRuntimeLoader(new FactoryRuntimeLoader([
+            AssetRuntime::class => static fn (): AssetRuntime => new AssetRuntime(new TagRenderer(
+                new EntrypointsLookup(__DIR__.'/../fixtures/build/entrypoints.json'),
+                new Packages(new PathPackage('/', new EmptyVersionStrategy())),
+            )),
+        ]));
+
+        $this->assertSame('yes|no', $twig->render('page'));
     }
 
     /**


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | yes
| License        | MIT

Adds a `reprise_entry_exists('name')` Twig function that returns a bool, the direct counterpart of Encore's `encore_entry_exists`. It lets templates guard page-specific or optional entries so that rendering their tags doesn't throw in strict mode when the entry isn't present in `entrypoints.json`:

```twig
{% if reprise_entry_exists('checkout') %}
    {{ reprise_entry_script_tags('checkout') }}
{% endif %}
```

The function delegates to the existing lookup's `entryExists()` method, so there's no new lookup path. Documented in `doc/index.rst` alongside the existing tag functions, with unit tests and Twig-level tests.
