### PR TITLE
[Twig] Add per-call attributes to the entry tag functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.6.0
+
+- Add a per-call `attributes` argument to the `reprise_entry_script_tags()` and `reprise_entry_link_tags()` Twig functions
+
 ## 0.5.0
 
 - Require Vite `^7.0` or `^8.0`; Vite 7 is now the minimum supported version

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -146,6 +146,16 @@ shape hasn't changed):
      - ``reprise_entry_js_files('app')``
      - JS URL list
 
+``reprise_entry_script_tags`` and ``reprise_entry_link_tags`` take a fourth ``attributes`` argument, merged over the
+global ``script_attributes``/``link_attributes`` (per-call wins, ``false`` drops the attribute). It mirrors Encore's
+fourth argument; since it follows the optional package name, pass it as a Twig named argument:
+
+.. code-block:: twig
+
+    {# a fourth `attributes` argument, merged over the configured script_attributes/link_attributes #}
+    {{ reprise_entry_script_tags('app', attributes={ 'data-turbo-track': 'reload' }) }}
+    {{ reprise_entry_link_tags('app', attributes={ media: 'print' }) }}
+
 **Nothing to set up for the common case.** The tags resolve against Symfony's default asset package, so a standard
 project needs nothing beyond installing the bundle (see `Configuration`_ below for the options). The snippet is the
 same whether Vite or Rsbuild produced ``entrypoints.json``, and there's nothing to configure for dev either: in dev

--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -45,8 +45,13 @@ final class TagRenderer implements ResetInterface
     ) {
     }
 
-    public function renderScriptTags(string $entryName, ?string $packageName = null): string
+    /**
+     * @param array<string, bool|string> $attributes per-call attributes, merged last so they win over the
+     *                                               configured script_attributes (integrity/crossorigin stay authoritative)
+     */
+    public function renderScriptTags(string $entryName, ?string $packageName = null, ?string $build = null, array $attributes = []): string
     {
+        $this->assertNoBuild($build);
         $integrity = $this->lookup->getIntegrityData();
         $tags = [];
 
@@ -61,34 +66,37 @@ final class TagRenderer implements ResetInterface
 
         foreach ($this->lookup->getPreloadFiles($entryName) as $reference) {
             $url = $this->url($reference, $packageName);
-            $attributes = ['rel' => 'modulepreload', 'href' => $url];
-            $this->applyIntegrity($attributes, $reference, $integrity);
-            $tags[] = \sprintf('<link %s>', $this->attributes($attributes));
+            $tagAttributes = ['rel' => 'modulepreload', 'href' => $url];
+            $this->applyIntegrity($tagAttributes, $reference, $integrity);
+            $tags[] = \sprintf('<link %s>', $this->attributes($tagAttributes));
             $this->preload($url, 'modulepreload');
         }
 
         foreach ($this->lookup->getJavaScriptFiles($entryName) as $reference) {
             $url = $this->url($reference, $packageName);
-            $attributes = ['src' => $url, 'type' => 'module'];
-            $attributes += $this->scriptAttributes;
-            $this->applyIntegrity($attributes, $reference, $integrity);
-            $tags[] = \sprintf('<script %s></script>', $this->attributes($attributes));
+            $tagAttributes = ['src' => $url, 'type' => 'module'] + $attributes + $this->scriptAttributes;
+            $this->applyIntegrity($tagAttributes, $reference, $integrity);
+            $tags[] = \sprintf('<script %s></script>', $this->attributes($tagAttributes));
             $this->preload($url, 'preload', 'script');
         }
 
         return implode('', $tags);
     }
 
-    public function renderLinkTags(string $entryName, ?string $packageName = null): string
+    /**
+     * @param array<string, bool|string> $attributes per-call attributes, merged last so they win over the
+     *                                               configured link_attributes (integrity/crossorigin stay authoritative)
+     */
+    public function renderLinkTags(string $entryName, ?string $packageName = null, ?string $build = null, array $attributes = []): string
     {
+        $this->assertNoBuild($build);
         $integrity = $this->lookup->getIntegrityData();
         $tags = [];
         foreach ($this->lookup->getCssFiles($entryName) as $reference) {
             $url = $this->url($reference, $packageName);
-            $attributes = ['rel' => 'stylesheet', 'href' => $url];
-            $attributes += $this->linkAttributes;
-            $this->applyIntegrity($attributes, $reference, $integrity);
-            $tags[] = \sprintf('<link %s>', $this->attributes($attributes));
+            $tagAttributes = ['rel' => 'stylesheet', 'href' => $url] + $attributes + $this->linkAttributes;
+            $this->applyIntegrity($tagAttributes, $reference, $integrity);
+            $tags[] = \sprintf('<link %s>', $this->attributes($tagAttributes));
             $this->preload($url, 'preload', 'style');
         }
 
@@ -135,6 +143,13 @@ final class TagRenderer implements ResetInterface
                 HTML,
             htmlspecialchars($reactRefreshUrl, \ENT_QUOTES),
         );
+    }
+
+    private function assertNoBuild(?string $build): void
+    {
+        if (null !== $build) {
+            throw new \InvalidArgumentException(\sprintf('No build named "%s" is configured.', $build));
+        }
     }
 
     private function url(string $reference, ?string $packageName): string

--- a/src/Twig/AssetRuntime.php
+++ b/src/Twig/AssetRuntime.php
@@ -32,14 +32,20 @@ final class AssetRuntime implements RuntimeExtensionInterface
     {
     }
 
-    public function renderScriptTags(string $entryName, ?string $packageName = null): string
+    /**
+     * @param array<string, bool|string> $attributes
+     */
+    public function renderScriptTags(string $entryName, ?string $packageName = null, ?string $build = null, array $attributes = []): string
     {
-        return $this->tagRenderer->renderScriptTags($entryName, $packageName);
+        return $this->tagRenderer->renderScriptTags($entryName, $packageName, $build, $attributes);
     }
 
-    public function renderLinkTags(string $entryName, ?string $packageName = null): string
+    /**
+     * @param array<string, bool|string> $attributes
+     */
+    public function renderLinkTags(string $entryName, ?string $packageName = null, ?string $build = null, array $attributes = []): string
     {
-        return $this->tagRenderer->renderLinkTags($entryName, $packageName);
+        return $this->tagRenderer->renderLinkTags($entryName, $packageName, $build, $attributes);
     }
 
     /**

--- a/tests/Asset/TagRendererTest.php
+++ b/tests/Asset/TagRendererTest.php
@@ -403,4 +403,86 @@ final class TagRendererTest extends TestCase
             $html,
         );
     }
+
+    public function testPerCallAttributesAreAppliedToScriptTags()
+    {
+        $html = $this->renderer(js: ['build/app.js'])
+            ->renderScriptTags('app', attributes: ['defer' => true, 'data-turbo-track' => 'reload']);
+
+        $this->assertSame('<script src="/build/app.js" type="module" defer data-turbo-track="reload"></script>', $html);
+    }
+
+    public function testPerCallAttributesAreAppliedToLinkTags()
+    {
+        $html = $this->renderer(css: ['build/app.css'])->renderLinkTags('app', attributes: ['media' => 'print']);
+
+        $this->assertSame('<link rel="stylesheet" href="/build/app.css" media="print">', $html);
+    }
+
+    public function testPerCallAttributesWinOverDefaultAttributes()
+    {
+        $html = $this->renderer(js: ['build/app.js'], scriptAttributes: ['data-turbo-track' => 'reload'])
+            ->renderScriptTags('app', attributes: ['data-turbo-track' => 'reload-only-on-this-page']);
+
+        $this->assertStringContainsString('data-turbo-track="reload-only-on-this-page"', $html);
+        $this->assertStringNotContainsString('data-turbo-track="reload"', $html);
+    }
+
+    public function testPerCallFalseValueDropsADefaultAttribute()
+    {
+        $html = $this->renderer(js: ['build/app.js'], scriptAttributes: ['defer' => true])
+            ->renderScriptTags('app', attributes: ['defer' => false]);
+
+        $this->assertSame('<script src="/build/app.js" type="module"></script>', $html);
+    }
+
+    public function testPerCallAttributesApplyToScriptsNotToModulepreloadLinks()
+    {
+        $html = $this->renderer(js: ['build/app.js'], preload: ['build/shared.js'])
+            ->renderScriptTags('app', attributes: ['data-turbo-track' => 'reload']);
+
+        // The per-call attribute rides on the <script>, never on the modulepreload <link>.
+        $this->assertSame(
+            '<link rel="modulepreload" href="/build/shared.js">'
+            .'<script src="/build/app.js" type="module" data-turbo-track="reload"></script>',
+            $html,
+        );
+    }
+
+    public function testPerCallAttributesDoNotLeakIntoTheHmrClient()
+    {
+        $html = $this->renderer(
+            js: ['http://127.0.0.1:5173/build/app.js'],
+            devServer: new DevServer('http://127.0.0.1:5173', 'http://127.0.0.1:5173/build/@vite/client'),
+        )->renderScriptTags('app', attributes: ['defer' => true]);
+
+        // The injected client tag is emitted verbatim; only the entry script carries the per-call attribute.
+        $this->assertStringContainsString('<script type="module" src="http://127.0.0.1:5173/build/@vite/client"></script>', $html);
+        $this->assertStringContainsString('src="http://127.0.0.1:5173/build/app.js" type="module" defer></script>', $html);
+    }
+
+    public function testPerCallAttributesCannotSpoofIntegrity()
+    {
+        $html = $this->renderer(
+            js: ['build/app-a1b2.js'],
+            integrity: ['build/app-a1b2.js' => 'sha384-REAL'],
+        )->renderScriptTags('app', attributes: ['integrity' => 'sha384-FAKE']);
+
+        $this->assertStringContainsString('integrity="sha384-REAL"', $html);
+        $this->assertStringNotContainsString('sha384-FAKE', $html);
+    }
+
+    public function testRenderingScriptTagsWithABuildNameThrowsUntilBuildsAreSupported()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->renderer(js: ['build/app.js'])->renderScriptTags('app', build: 'admin');
+    }
+
+    public function testRenderingLinkTagsWithABuildNameThrowsUntilBuildsAreSupported()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->renderer(css: ['build/app.css'])->renderLinkTags('app', build: 'admin');
+    }
 }

--- a/tests/Twig/AssetExtensionTest.php
+++ b/tests/Twig/AssetExtensionTest.php
@@ -73,6 +73,22 @@ final class AssetExtensionTest extends TestCase
         );
     }
 
+    public function testScriptTagsAcceptPerCallAttributesViaNamedArgument()
+    {
+        $twig = new Environment(new ArrayLoader([
+            'page' => "{{ reprise_entry_script_tags('app', attributes={'defer': true, 'data-turbo-track': 'reload'}) }}",
+        ]));
+        $twig->addExtension(new AssetExtension());
+        $twig->addRuntimeLoader(new FactoryRuntimeLoader([
+            AssetRuntime::class => fn (): AssetRuntime => new AssetRuntime($this->tagRenderer(['build/app.js'])),
+        ]));
+
+        $this->assertSame(
+            '<script src="/build/app.js" type="module" defer data-turbo-track="reload"></script>',
+            $twig->render('page'),
+        );
+    }
+
     /**
      * @param list<string> $js
      * @param list<string> $css


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | yes
| License        | MIT

`reprise_entry_script_tags` and `reprise_entry_link_tags` now accept a per-call `attributes` map, equivalent to the fourth argument of Encore's `encore_entry_script_tags`. Per-call attributes are merged over the globally configured `script_attributes`/`link_attributes`, with the per-call value winning on conflict; passing `false` for a key drops that attribute for the call. SRI `integrity` and `crossorigin` remain authoritative and can't be overridden per-call. The attributes apply only to the entry's own `<script>`/`<link>` tags, not to injected modulepreload links or the dev HMR client.

```twig
{{ reprise_entry_script_tags('app', attributes={ 'data-turbo-track': 'reload' }) }}
{{ reprise_entry_link_tags('app', attributes={ media: 'print' }) }}
```

The method signature also gains a reserved `build` argument (positioned before `attributes`) that currently throws, laying groundwork for a later multiple-builds feature. Documented in `doc/index.rst`, with unit and Twig tests.
