### PR TITLE
[Builds] Add support for multiple named builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add a per-call `attributes` argument to the `reprise_entry_script_tags()` and `reprise_entry_link_tags()` Twig functions
 - Add the `reprise_entry_exists()` Twig function
+- Add support for multiple named builds via the `builds` config and a `build` argument on the Twig functions
 
 ## 0.5.0
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Symfony Reprise covers only the Symfony-side glue the bundlers leave out:
 - 🔖 **Asset versioning**: content-hash cache busting, wired into the manifest
 - 📁 **File copy**: copy static files (images, fonts…) into the build, keyed in the manifest
 - 🔥 **Dev server & HMR**: points Twig at the running Vite/Rsbuild server
+- 🧱 **Multiple builds**: drive several bundles (e.g. a main app and a separately-built embeddable widget) from one Symfony app
 - 🏷️ **Twig tag rendering**: `reprise_entry_script_tags`/`reprise_entry_link_tags` render straight from `entrypoints.json`
 - 🧩 **Symfony UX / Stimulus**: registers `controllers.json` and local controllers, eager or lazy
 - 🌐 **CDN support**: serve built assets from an absolute `publicPath`

--- a/config/cache.php
+++ b/config/cache.php
@@ -31,8 +31,7 @@ return static function (ContainerConfigurator $container): void {
 
     $services->set('reprise.entrypoints_cache_warmer', EntrypointsCacheWarmer::class)
         ->args([
-            param('reprise.entrypoints_path'),
-            'reprise.entrypoints',
+            param('reprise.entrypoints_paths'),
             service('reprise.cache'),
         ])
         ->tag('kernel.cache_warmer')

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,6 +17,7 @@ reimplement any of that. It covers only the Symfony-side glue the bundlers leave
 - **Asset versioning**: content-hash cache busting, wired into the manifest
 - **File copy**: copy static files into the build, keyed in the manifest
 - **Dev server and HMR**: points Twig at the running Vite/Rsbuild server
+- **Multiple builds**: drive several bundles (e.g. a main app and a separately-built embeddable widget) from one Symfony app
 - **Twig tag rendering**: ``reprise_entry_script_tags``/``reprise_entry_link_tags`` render straight from
   ``entrypoints.json``
 - **Symfony UX / Stimulus**: registers ``controllers.json`` and local controllers, eager or lazy
@@ -456,6 +457,89 @@ The resulting ``entrypoints.json`` gets an extra ``integrity`` section:
 Hashes cover every referenced file in each entry (js, css, and preloaded/dynamic chunks), and since they're computed
 from the files actually written to disk, they stay correct through minification and hashing.
 
+Multiple builds
+~~~~~~~~~~~~~~~
+
+Several areas of one app (a public part, an admin panel) are usually just separate entry points in one config: the
+Multiple entries case, addressed by name without a ``build`` argument. Reach for multiple builds only when a part
+needs its own bundler config and output directory, like an embeddable widget built apart from the main app.
+
+Give the widget its own config, pointing the plugin at a separate output directory -> with Vite:
+
+.. code-block:: javascript
+
+    // vite.config.widget.ts  -- run with `vite build --config vite.config.widget.ts`
+    import { defineConfig } from 'vite'
+    import Symfony from '@symfony/reprise/vite'
+
+    export default defineConfig({
+      build: {
+        rolldownOptions: {
+          input: {
+            widget: './assets/widget.js',
+          },
+        },
+      },
+      plugins: [
+        Symfony({
+          outputPath: 'public/widget-build',
+          publicPath: '/widget-build/',
+        }),
+      ],
+    })
+
+or with Rsbuild:
+
+.. code-block:: javascript
+
+    // rsbuild.config.widget.ts  -- run with `rsbuild build --config rsbuild.config.widget.ts`
+    import { defineConfig } from '@rsbuild/core'
+    import Symfony from '@symfony/reprise/rsbuild'
+
+    export default defineConfig({
+      source: {
+        entry: {
+          widget: './assets/widget.js',
+        },
+      },
+      plugins: [
+        Symfony({
+          outputPath: 'public/widget-build',
+          publicPath: '/widget-build/',
+        }),
+      ],
+    })
+
+These two blocks are alternatives: pick the one that matches your bundler, you don't use both in one project.
+
+Name that directory in ``reprise.yaml``:
+
+.. code-block:: yaml
+
+    # config/packages/reprise.yaml
+    reprise:
+        # the main app (your existing config), addressed without a build name
+        output_path: '%kernel.project_dir%/public/build'
+        builds:
+            # each extra build: name -> the directory its entrypoints.json lives in
+            widget: '%kernel.project_dir%/public/widget-build'
+
+In Twig, pass the build name to load from it; omit it for the default build:
+
+.. code-block:: twig
+
+    {# the main app (default build) #}
+    {{ reprise_entry_script_tags('app') }}
+    {{ reprise_entry_link_tags('app') }}
+
+    {# the widget build, selected with the build argument #}
+    {{ reprise_entry_script_tags('widget', build='widget') }}
+    {{ reprise_entry_link_tags('widget', build='widget') }}
+
+The ``build`` argument works on every ``reprise_entry_*`` function. Each build has its own dev server, so the app's
+and the widget's can run at once on different ports, each injecting its HMR client once. Set ``output_path: false``
+for a named-builds-only setup (at least one build is required).
+
 Configuration
 -------------
 
@@ -466,7 +550,11 @@ Reprise exposes a few optional settings under its own configuration, all shown h
     # config/packages/reprise.yaml
     reprise:
         # Directory the @symfony/reprise plugin writes entrypoints.json and manifest.json into.
+        # Set to false when using only named builds (requires at least one entry under builds).
         output_path: '%kernel.project_dir%/public/build'
+
+        # Additional named builds: a map of build name -> output directory (see `Multiple builds`_).
+        builds: {}
 
         # Throw when entrypoints.json or a requested entry is missing, instead of rendering nothing.
         strict_mode: true
@@ -488,7 +576,10 @@ Reprise exposes a few optional settings under its own configuration, all shown h
         link_attributes: []
 
 - ``output_path``: filesystem directory holding ``entrypoints.json`` and ``manifest.json``. Must match the plugin's
-  own ``outputPath``.
+  own ``outputPath``. Accepts ``false`` to disable the default build entirely (requires at least one entry under
+  ``builds``).
+- ``builds``: a map of build name -> output directory for additional bundles. Each named build is addressed by passing
+  ``build='<name>'`` to the tag and file functions. See `Multiple builds`_.
 - ``strict_mode``: when ``true`` (the default), throws a clear exception on a missing file or an unknown entry; when
   ``false``, renders nothing instead.
 - ``cache``: when ``true``, parse ``entrypoints.json`` once at ``cache:warmup`` and read it from a compiled PHP file

--- a/src/Asset/EntrypointsLookupCollection.php
+++ b/src/Asset/EntrypointsLookupCollection.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Asset;
+
+use Symfony\Contracts\Service\ServiceProviderInterface;
+use Symfony\Reprise\Exception\UndefinedBuildException;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class EntrypointsLookupCollection implements EntrypointsLookupCollectionInterface
+{
+    /**
+     * @param ServiceProviderInterface<EntrypointsLookupInterface> $lookups a service locator keyed by build name (the default build under "_default")
+     */
+    public function __construct(
+        private readonly ServiceProviderInterface $lookups,
+        private readonly ?string $defaultBuildName = null,
+    ) {
+    }
+
+    public function getEntrypointsLookup(?string $build = null): EntrypointsLookupInterface
+    {
+        $build ??= $this->defaultBuildName;
+
+        if (null === $build) {
+            throw new UndefinedBuildException('There is no default build configured: set "reprise.output_path", or pass an explicit build name.');
+        }
+
+        if (!$this->lookups->has($build)) {
+            throw new UndefinedBuildException(\sprintf('The build "%s" is not configured under "reprise.builds".', $build));
+        }
+
+        return $this->lookups->get($build);
+    }
+}

--- a/src/Asset/EntrypointsLookupCollectionInterface.php
+++ b/src/Asset/EntrypointsLookupCollectionInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Asset;
+
+use Symfony\Reprise\Exception\UndefinedBuildException;
+
+/**
+ * Resolves the EntrypointsLookup for a named build (or the default build when none is given).
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+interface EntrypointsLookupCollectionInterface
+{
+    /**
+     * @throws UndefinedBuildException when the build is unknown, or when null is given and no default build exists
+     */
+    public function getEntrypointsLookup(?string $build = null): EntrypointsLookupInterface;
+}

--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -27,14 +27,20 @@ use Symfony\Contracts\Service\ResetInterface;
  */
 final class TagRenderer implements ResetInterface
 {
-    private bool $clientInjected = false;
+    /**
+     * HMR client URLs already injected this request, kept as a set so each dev server (there is one per
+     * build) injects its client exactly once, even when several builds render on the same page.
+     *
+     * @var array<string, true>
+     */
+    private array $injectedClients = [];
 
     /**
      * @param array<string, bool|string> $scriptAttributes
      * @param array<string, bool|string> $linkAttributes
      */
     public function __construct(
-        private readonly EntrypointsLookupInterface $lookup,
+        private readonly EntrypointsLookupCollectionInterface $collection,
         private readonly Packages $packages,
         private readonly ?RequestStack $requestStack = null,
         private readonly ?string $defaultPackage = null,
@@ -51,20 +57,20 @@ final class TagRenderer implements ResetInterface
      */
     public function renderScriptTags(string $entryName, ?string $packageName = null, ?string $build = null, array $attributes = []): string
     {
-        $this->assertNoBuild($build);
-        $integrity = $this->lookup->getIntegrityData();
+        $lookup = $this->collection->getEntrypointsLookup($build);
+        $integrity = $lookup->getIntegrityData();
         $tags = [];
 
-        $devServer = $this->lookup->getDevServer();
-        if (!$this->clientInjected && null !== $devServer && null !== $devServer->client) {
+        $devServer = $lookup->getDevServer();
+        if (null !== $devServer && null !== $devServer->client && !isset($this->injectedClients[$devServer->client])) {
             $tags[] = \sprintf('<script type="module" src="%s"></script>', htmlspecialchars($devServer->client, \ENT_QUOTES));
             if (null !== $devServer->reactRefresh) {
                 $tags[] = $this->renderReactRefreshPreamble($devServer->reactRefresh);
             }
-            $this->clientInjected = true;
+            $this->injectedClients[$devServer->client] = true;
         }
 
-        foreach ($this->lookup->getPreloadFiles($entryName) as $reference) {
+        foreach ($lookup->getPreloadFiles($entryName) as $reference) {
             $url = $this->url($reference, $packageName);
             $tagAttributes = ['rel' => 'modulepreload', 'href' => $url];
             $this->applyIntegrity($tagAttributes, $reference, $integrity);
@@ -72,7 +78,7 @@ final class TagRenderer implements ResetInterface
             $this->preload($url, 'modulepreload');
         }
 
-        foreach ($this->lookup->getJavaScriptFiles($entryName) as $reference) {
+        foreach ($lookup->getJavaScriptFiles($entryName) as $reference) {
             $url = $this->url($reference, $packageName);
             $tagAttributes = ['src' => $url, 'type' => 'module'] + $attributes + $this->scriptAttributes;
             $this->applyIntegrity($tagAttributes, $reference, $integrity);
@@ -89,10 +95,10 @@ final class TagRenderer implements ResetInterface
      */
     public function renderLinkTags(string $entryName, ?string $packageName = null, ?string $build = null, array $attributes = []): string
     {
-        $this->assertNoBuild($build);
-        $integrity = $this->lookup->getIntegrityData();
+        $lookup = $this->collection->getEntrypointsLookup($build);
+        $integrity = $lookup->getIntegrityData();
         $tags = [];
-        foreach ($this->lookup->getCssFiles($entryName) as $reference) {
+        foreach ($lookup->getCssFiles($entryName) as $reference) {
             $url = $this->url($reference, $packageName);
             $tagAttributes = ['rel' => 'stylesheet', 'href' => $url] + $attributes + $this->linkAttributes;
             $this->applyIntegrity($tagAttributes, $reference, $integrity);
@@ -106,27 +112,27 @@ final class TagRenderer implements ResetInterface
     /**
      * @return list<string>
      */
-    public function getJsFiles(string $entryName, ?string $packageName = null): array
+    public function getJsFiles(string $entryName, ?string $packageName = null, ?string $build = null): array
     {
-        return array_map(fn (string $r) => $this->url($r, $packageName), $this->lookup->getJavaScriptFiles($entryName));
+        return array_map(fn (string $r) => $this->url($r, $packageName), $this->collection->getEntrypointsLookup($build)->getJavaScriptFiles($entryName));
     }
 
     /**
      * @return list<string>
      */
-    public function getCssFiles(string $entryName, ?string $packageName = null): array
+    public function getCssFiles(string $entryName, ?string $packageName = null, ?string $build = null): array
     {
-        return array_map(fn (string $r) => $this->url($r, $packageName), $this->lookup->getCssFiles($entryName));
+        return array_map(fn (string $r) => $this->url($r, $packageName), $this->collection->getEntrypointsLookup($build)->getCssFiles($entryName));
     }
 
-    public function entryExists(string $entryName): bool
+    public function entryExists(string $entryName, ?string $build = null): bool
     {
-        return $this->lookup->entryExists($entryName);
+        return $this->collection->getEntrypointsLookup($build)->entryExists($entryName);
     }
 
     public function reset(): void
     {
-        $this->clientInjected = false;
+        $this->injectedClients = [];
     }
 
     /**
@@ -148,13 +154,6 @@ final class TagRenderer implements ResetInterface
                 HTML,
             htmlspecialchars($reactRefreshUrl, \ENT_QUOTES),
         );
-    }
-
-    private function assertNoBuild(?string $build): void
-    {
-        if (null !== $build) {
-            throw new \InvalidArgumentException(\sprintf('No build named "%s" is configured.', $build));
-        }
     }
 
     private function url(string $reference, ?string $packageName): string

--- a/src/CacheWarmer/EntrypointsCacheWarmer.php
+++ b/src/CacheWarmer/EntrypointsCacheWarmer.php
@@ -25,9 +25,11 @@ use Symfony\Reprise\Asset\Entrypoints;
  */
 final class EntrypointsCacheWarmer implements CacheWarmerInterface
 {
+    /**
+     * @param array<string, string> $entrypointsPaths build name => entrypoints.json path
+     */
     public function __construct(
-        private readonly string $entrypointsPath,
-        private readonly string $cacheKey,
+        private readonly array $entrypointsPaths,
         private readonly PhpArrayAdapter $cache,
     ) {
     }
@@ -39,17 +41,24 @@ final class EntrypointsCacheWarmer implements CacheWarmerInterface
 
     public function warmUp(string $cacheDir, ?string $buildDir = null): array
     {
-        if (!is_file($this->entrypointsPath)) {
-            return [];
+        $values = [];
+        foreach ($this->entrypointsPaths as $build => $path) {
+            if (!is_file($path)) {
+                continue;
+            }
+
+            try {
+                $decoded = json_decode((string) file_get_contents($path), true, flags: \JSON_THROW_ON_ERROR);
+                if (\is_array($decoded)) {
+                    $values['reprise.entrypoints.'.$build] = Entrypoints::fromArray($decoded);
+                }
+            } catch (\Throwable) {
+                // A malformed entrypoints.json at deploy time must not break cache:warmup.
+            }
         }
 
-        try {
-            $decoded = json_decode((string) file_get_contents($this->entrypointsPath), true, flags: \JSON_THROW_ON_ERROR);
-            if (\is_array($decoded)) {
-                $this->cache->warmUp([$this->cacheKey => Entrypoints::fromArray($decoded)]);
-            }
-        } catch (\Throwable) {
-            // A malformed entrypoints.json at deploy time must not break cache:warmup.
+        if ($values) {
+            $this->cache->warmUp($values);
         }
 
         return [];

--- a/src/EventListener/ResetAssetsEventListener.php
+++ b/src/EventListener/ResetAssetsEventListener.php
@@ -15,13 +15,12 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Reprise\Asset\EntrypointsLookupInterface;
-use Symfony\Reprise\Asset\TagRenderer;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
- * Clears the per-request asset state (lookup dedup + renderer client flag) once the main request finishes,
- * so a long-running worker (FrankenPHP, RoadRunner, ...) starts afresh, and on an exception before
- * ErrorListener renders the error page, so that page still gets the full tag set.
+ * Resets the per-request asset state (every build's lookup dedup set and the renderer's injected clients)
+ * once the main request finishes, so a long-running worker (FrankenPHP, RoadRunner, ...) starts afresh,
+ * and on an exception before ErrorListener renders the error page, so that page still gets the full tag set.
  *
  * @author Hugo Alliaume <hugo@alliau.me>
  *
@@ -29,9 +28,11 @@ use Symfony\Reprise\Asset\TagRenderer;
  */
 final class ResetAssetsEventListener implements EventSubscriberInterface
 {
+    /**
+     * @param iterable<ResetInterface> $resettables
+     */
     public function __construct(
-        private readonly EntrypointsLookupInterface $entrypointsLookup,
-        private readonly TagRenderer $tagRenderer,
+        private readonly iterable $resettables,
     ) {
     }
 
@@ -60,7 +61,8 @@ final class ResetAssetsEventListener implements EventSubscriberInterface
 
     private function reset(): void
     {
-        $this->entrypointsLookup->reset();
-        $this->tagRenderer->reset();
+        foreach ($this->resettables as $resettable) {
+            $resettable->reset();
+        }
     }
 }

--- a/src/Exception/UndefinedBuildException.php
+++ b/src/Exception/UndefinedBuildException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Exception;
+
+/**
+ * Thrown when a requested build name is not configured under "reprise.builds".
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class UndefinedBuildException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/RepriseBundle.php
+++ b/src/RepriseBundle.php
@@ -17,6 +17,8 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
 use Symfony\Component\VarExporter\VarExporter;
 use Symfony\Reprise\Asset\EntrypointsLookup;
+use Symfony\Reprise\Asset\EntrypointsLookupCollection;
+use Symfony\Reprise\Asset\EntrypointsLookupCollectionInterface;
 use Symfony\Reprise\Asset\EntrypointsLookupInterface;
 use Symfony\Reprise\Asset\TagRenderer;
 use Symfony\Reprise\EventListener\ResetAssetsEventListener;
@@ -24,6 +26,7 @@ use Symfony\Reprise\Twig\AssetExtension;
 use Symfony\Reprise\Twig\AssetRuntime;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service_locator;
 
 /**
  * @author Hugo Alliaume <hugo@alliau.me>
@@ -36,7 +39,17 @@ final class RepriseBundle extends AbstractBundle
             ->children()
                 ->scalarNode('output_path')
                     ->defaultValue('%kernel.project_dir%/public/build')
-                    ->info('Directory where the @symfony/reprise plugin writes entrypoints.json and manifest.json.')
+                    ->info('Directory where the @symfony/reprise plugin writes entrypoints.json and manifest.json. Set to false to only use named "builds".')
+                ->end()
+                ->arrayNode('builds')
+                    ->info('Additional named builds: a map of build name to output directory, each with its own entrypoints.json.')
+                    ->useAttributeAsKey('name')
+                    ->scalarPrototype()->end()
+                    ->defaultValue([])
+                    ->validate()
+                        ->ifTrue(static fn (array $builds): bool => \array_key_exists('_default', $builds))
+                        ->thenInvalid('The build name "_default" is reserved for "reprise.output_path".')
+                    ->end()
                 ->end()
                 ->booleanNode('strict_mode')
                     ->defaultTrue()
@@ -72,44 +85,69 @@ final class RepriseBundle extends AbstractBundle
     }
 
     /**
-     * @param array{output_path: string, strict_mode: bool, cache: bool, preload: bool, asset_package: ?string, crossorigin: string|false, script_attributes: array<string, bool|string>, link_attributes: array<string, bool|string>} $config
+     * @param array{output_path: string|false, builds: array<string, string>, strict_mode: bool, cache: bool, preload: bool, asset_package: ?string, crossorigin: string|false, script_attributes: array<string, bool|string>, link_attributes: array<string, bool|string>} $config
      */
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
         $services = $container->services();
 
-        $entrypointsPath = $config['output_path'].'/entrypoints.json';
-
         if ($config['cache'] && !class_exists(VarExporter::class)) {
             throw new \LogicException('Enabling "reprise.cache" requires the Symfony Cache component. Run "composer require symfony/cache".');
         }
 
-        $lookupArgs = [$entrypointsPath, $config['strict_mode']];
-        if ($config['cache']) {
-            $lookupArgs[] = service('reprise.cache');
-            $lookupArgs[] = 'reprise.entrypoints';
+        // Build the map of build name -> entrypoints.json path. The default build (from output_path) is
+        // keyed "_default"; named builds keep their configured name.
+        $entrypointsPaths = [];
+        if (false !== $config['output_path']) {
+            $entrypointsPaths['_default'] = $config['output_path'].'/entrypoints.json';
+        }
+        foreach ($config['builds'] as $name => $dir) {
+            $entrypointsPaths[$name] = $dir.'/entrypoints.json';
+        }
+        if (!$entrypointsPaths) {
+            throw new \LogicException('Configure at least one build: set "reprise.output_path" or add entries under "reprise.builds".');
         }
 
-        $services->set('reprise.entrypoints_lookup', EntrypointsLookup::class)
-            ->args($lookupArgs)
-            ->tag('kernel.reset', ['method' => 'reset'])
-        ;
+        $lookupLocator = [];
+        $resettables = [];
+        foreach ($entrypointsPaths as $name => $path) {
+            $serviceId = '_default' === $name ? 'reprise.entrypoints_lookup' : 'reprise.entrypoints_lookup.'.$name;
+
+            $lookupArgs = [$path, $config['strict_mode']];
+            if ($config['cache']) {
+                $lookupArgs[] = service('reprise.cache');
+                $lookupArgs[] = 'reprise.entrypoints.'.$name;
+            }
+
+            $services->set($serviceId, EntrypointsLookup::class)
+                ->args($lookupArgs)
+                ->tag('kernel.reset', ['method' => 'reset'])
+            ;
+
+            $lookupLocator[$name] = service($serviceId);
+            $resettables[] = service($serviceId);
+        }
 
         if ($config['cache']) {
-            $container->parameters()->set('reprise.entrypoints_path', $entrypointsPath);
+            $container->parameters()->set('reprise.entrypoints_paths', $entrypointsPaths);
             $container->import('../config/cache.php');
         }
 
-        $services->alias(EntrypointsLookupInterface::class, 'reprise.entrypoints_lookup');
+        $defaultBuild = false !== $config['output_path'] ? '_default' : null;
 
-        $services->set('reprise.reset_assets_listener', ResetAssetsEventListener::class)
-            ->args([service('reprise.entrypoints_lookup'), service('reprise.tag_renderer')])
-            ->tag('kernel.event_subscriber')
+        $services->set('reprise.entrypoints_lookup_collection', EntrypointsLookupCollection::class)
+            ->args([service_locator($lookupLocator), $defaultBuild])
         ;
+        $services->alias(EntrypointsLookupCollectionInterface::class, 'reprise.entrypoints_lookup_collection');
+
+        // Keep the default lookup autowirable by its interface (BC), but only when there is a default build.
+        if (null !== $defaultBuild) {
+            $services->alias(EntrypointsLookupInterface::class, 'reprise.entrypoints_lookup');
+        }
 
         $services->set('reprise.tag_renderer', TagRenderer::class)
             ->args([
-                service('reprise.entrypoints_lookup'),
+                service('reprise.entrypoints_lookup_collection'),
                 service('assets.packages'),
                 service('request_stack'),
                 $config['asset_package'],
@@ -119,6 +157,12 @@ final class RepriseBundle extends AbstractBundle
                 $config['link_attributes'],
             ])
             ->tag('kernel.reset', ['method' => 'reset'])
+        ;
+
+        $resettables[] = service('reprise.tag_renderer');
+        $services->set('reprise.reset_assets_listener', ResetAssetsEventListener::class)
+            ->args([$resettables])
+            ->tag('kernel.event_subscriber')
         ;
 
         $services->set('reprise.asset_runtime', AssetRuntime::class)

--- a/src/Twig/AssetRuntime.php
+++ b/src/Twig/AssetRuntime.php
@@ -51,21 +51,21 @@ final class AssetRuntime implements RuntimeExtensionInterface
     /**
      * @return list<string>
      */
-    public function getJsFiles(string $entryName, ?string $packageName = null): array
+    public function getJsFiles(string $entryName, ?string $packageName = null, ?string $build = null): array
     {
-        return $this->tagRenderer->getJsFiles($entryName, $packageName);
+        return $this->tagRenderer->getJsFiles($entryName, $packageName, $build);
     }
 
     /**
      * @return list<string>
      */
-    public function getCssFiles(string $entryName, ?string $packageName = null): array
+    public function getCssFiles(string $entryName, ?string $packageName = null, ?string $build = null): array
     {
-        return $this->tagRenderer->getCssFiles($entryName, $packageName);
+        return $this->tagRenderer->getCssFiles($entryName, $packageName, $build);
     }
 
-    public function entryExists(string $entryName): bool
+    public function entryExists(string $entryName, ?string $build = null): bool
     {
-        return $this->tagRenderer->entryExists($entryName);
+        return $this->tagRenderer->entryExists($entryName, $build);
     }
 }

--- a/tests/Asset/EntrypointsLookupCollectionTest.php
+++ b/tests/Asset/EntrypointsLookupCollectionTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Tests\Asset;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Reprise\Asset\EntrypointsLookup;
+use Symfony\Reprise\Asset\EntrypointsLookupCollection;
+use Symfony\Reprise\Exception\UndefinedBuildException;
+
+final class EntrypointsLookupCollectionTest extends TestCase
+{
+    private function lookup(): EntrypointsLookup
+    {
+        return new EntrypointsLookup(__DIR__.'/../fixtures/build/entrypoints.json');
+    }
+
+    public function testResolvesTheDefaultBuildWhenNoNameIsGiven()
+    {
+        $default = $this->lookup();
+        $collection = new EntrypointsLookupCollection(
+            new ServiceLocator(['_default' => static fn () => $default, 'admin' => fn () => $this->lookup()]),
+            '_default',
+        );
+
+        $this->assertSame($default, $collection->getEntrypointsLookup());
+        $this->assertSame($default, $collection->getEntrypointsLookup('_default'));
+    }
+
+    public function testResolvesANamedBuild()
+    {
+        $admin = $this->lookup();
+        $collection = new EntrypointsLookupCollection(
+            new ServiceLocator(['_default' => fn () => $this->lookup(), 'admin' => static fn () => $admin]),
+            '_default',
+        );
+
+        $this->assertSame($admin, $collection->getEntrypointsLookup('admin'));
+    }
+
+    public function testThrowsForAnUnknownBuild()
+    {
+        $collection = new EntrypointsLookupCollection(
+            new ServiceLocator(['_default' => fn () => $this->lookup()]),
+            '_default',
+        );
+
+        $this->expectException(UndefinedBuildException::class);
+        $collection->getEntrypointsLookup('does-not-exist');
+    }
+
+    public function testThrowsWhenNoBuildIsGivenAndThereIsNoDefault()
+    {
+        $collection = new EntrypointsLookupCollection(
+            new ServiceLocator(['admin' => fn () => $this->lookup()]),
+            null,
+        );
+
+        $this->expectException(UndefinedBuildException::class);
+        $collection->getEntrypointsLookup();
+    }
+}

--- a/tests/Asset/TagRendererTest.php
+++ b/tests/Asset/TagRendererTest.php
@@ -23,9 +23,13 @@ use Symfony\Reprise\Asset\DevServer;
 use Symfony\Reprise\Asset\EntrypointsLookup;
 use Symfony\Reprise\Asset\EntrypointsLookupInterface;
 use Symfony\Reprise\Asset\TagRenderer;
+use Symfony\Reprise\Exception\UndefinedBuildException;
+use Symfony\Reprise\Tests\BuildCollectionTrait;
 
 final class TagRendererTest extends TestCase
 {
+    use BuildCollectionTrait;
+
     private function renderer(
         array $js = [],
         array $css = [],
@@ -39,7 +43,28 @@ final class TagRendererTest extends TestCase
         bool $preloadEnabled = true,
         ?Packages $packages = null,
     ): TagRenderer {
-        $lookup = new class($js, $css, $preload, $integrity, $devServer) implements EntrypointsLookupInterface {
+        $packages ??= new Packages(new PathPackage('/', new EmptyVersionStrategy()));
+
+        return new TagRenderer(
+            $this->collection(['_default' => $this->lookup($js, $css, $preload, $integrity, $devServer)]),
+            $packages,
+            $requestStack,
+            null,
+            $crossorigin,
+            $preloadEnabled,
+            $scriptAttributes,
+            $linkAttributes,
+        );
+    }
+
+    private function lookup(
+        array $js = [],
+        array $css = [],
+        array $preload = [],
+        array $integrity = [],
+        ?DevServer $devServer = null,
+    ): EntrypointsLookupInterface {
+        return new class($js, $css, $preload, $integrity, $devServer) implements EntrypointsLookupInterface {
             public function __construct(
                 private array $js,
                 private array $css,
@@ -93,19 +118,6 @@ final class TagRendererTest extends TestCase
             {
             }
         };
-
-        $packages ??= new Packages(new PathPackage('/', new EmptyVersionStrategy()));
-
-        return new TagRenderer(
-            $lookup,
-            $packages,
-            $requestStack,
-            null,
-            $crossorigin,
-            $preloadEnabled,
-            $scriptAttributes,
-            $linkAttributes,
-        );
     }
 
     public function testRendersModuleScriptTagsWithPackagesResolvedSrc()
@@ -396,7 +408,7 @@ final class TagRendererTest extends TestCase
     public function testEntryExistsDelegatesToTheLookup()
     {
         $renderer = new TagRenderer(
-            new EntrypointsLookup(__DIR__.'/../fixtures/build/entrypoints.json'),
+            $this->collection(['_default' => new EntrypointsLookup(__DIR__.'/../fixtures/build/entrypoints.json')]),
             new Packages(new PathPackage('/', new EmptyVersionStrategy())),
         );
 
@@ -484,17 +496,52 @@ final class TagRendererTest extends TestCase
         $this->assertStringNotContainsString('sha384-FAKE', $html);
     }
 
-    public function testRenderingScriptTagsWithABuildNameThrowsUntilBuildsAreSupported()
+    public function testRenderingScriptTagsForAnUnknownBuildThrows()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(UndefinedBuildException::class);
 
         $this->renderer(js: ['build/app.js'])->renderScriptTags('app', build: 'admin');
     }
 
-    public function testRenderingLinkTagsWithABuildNameThrowsUntilBuildsAreSupported()
+    public function testRenderingLinkTagsForAnUnknownBuildThrows()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(UndefinedBuildException::class);
 
         $this->renderer(css: ['build/app.css'])->renderLinkTags('app', build: 'admin');
+    }
+
+    public function testRendersTheRequestedBuild()
+    {
+        $renderer = new TagRenderer(
+            $this->collection([
+                '_default' => $this->lookup(js: ['build/app.js']),
+                'admin' => $this->lookup(js: ['admin/dashboard.js']),
+            ]),
+            new Packages(new PathPackage('/', new EmptyVersionStrategy())),
+        );
+
+        $this->assertSame('<script src="/build/app.js" type="module"></script>', $renderer->renderScriptTags('app'));
+        $this->assertSame('<script src="/admin/dashboard.js" type="module"></script>', $renderer->renderScriptTags('dashboard', build: 'admin'));
+    }
+
+    public function testInjectsEachBuildsHmrClientOncePerRequest()
+    {
+        $renderer = new TagRenderer(
+            $this->collection([
+                '_default' => $this->lookup(js: ['http://127.0.0.1:5173/build/app.js'], devServer: new DevServer('http://127.0.0.1:5173', 'http://127.0.0.1:5173/build/@vite/client')),
+                'admin' => $this->lookup(js: ['http://127.0.0.1:3000/admin/app.js'], devServer: new DevServer('http://127.0.0.1:3000', 'http://127.0.0.1:3000/admin/@vite/client')),
+            ]),
+            new Packages(new PathPackage('/', new EmptyVersionStrategy())),
+        );
+
+        // Each build's dev server injects its own client exactly once, even on the same page.
+        $default = $renderer->renderScriptTags('app');
+        $admin = $renderer->renderScriptTags('app', build: 'admin');
+        $this->assertStringContainsString('http://127.0.0.1:5173/build/@vite/client', $default);
+        $this->assertStringContainsString('http://127.0.0.1:3000/admin/@vite/client', $admin);
+
+        // A second render of either build no longer re-injects its client.
+        $this->assertStringNotContainsString('@vite/client', $renderer->renderScriptTags('app'));
+        $this->assertStringNotContainsString('@vite/client', $renderer->renderScriptTags('app', build: 'admin'));
     }
 }

--- a/tests/BuildCollectionTrait.php
+++ b/tests/BuildCollectionTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Tests;
+
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Reprise\Asset\EntrypointsLookupCollection;
+use Symfony\Reprise\Asset\EntrypointsLookupInterface;
+
+trait BuildCollectionTrait
+{
+    /**
+     * @param array<string, EntrypointsLookupInterface> $lookups
+     */
+    private function collection(array $lookups, ?string $default = '_default'): EntrypointsLookupCollection
+    {
+        return new EntrypointsLookupCollection(
+            new ServiceLocator(array_map(static fn (EntrypointsLookupInterface $l): \Closure => static fn (): EntrypointsLookupInterface => $l, $lookups)),
+            $default,
+        );
+    }
+}

--- a/tests/CacheWarmer/EntrypointsCacheWarmerTest.php
+++ b/tests/CacheWarmer/EntrypointsCacheWarmerTest.php
@@ -35,8 +35,7 @@ final class EntrypointsCacheWarmerTest extends TestCase
     public function testWarmsThePoolFromTheEntrypointsFile()
     {
         $warmer = new EntrypointsCacheWarmer(
-            __DIR__.'/../fixtures/build/entrypoints.json',
-            'reprise.entrypoints',
+            ['_default' => __DIR__.'/../fixtures/build/entrypoints.json'],
             new PhpArrayAdapter($this->file, new ArrayAdapter()),
         );
 
@@ -44,19 +43,35 @@ final class EntrypointsCacheWarmerTest extends TestCase
         $this->assertSame([], $warmer->warmUp(sys_get_temp_dir()));
 
         // A fresh adapter reading the compiled file must hit and hold a built Entrypoints object.
-        $item = new PhpArrayAdapter($this->file, new ArrayAdapter())->getItem('reprise.entrypoints');
+        $item = new PhpArrayAdapter($this->file, new ArrayAdapter())->getItem('reprise.entrypoints._default');
         $this->assertTrue($item->isHit());
         $this->assertInstanceOf(Entrypoints::class, $item->get());
         $this->assertSame(['build/app-a1b2.js'], $item->get()->entryPoints['app']->js);
     }
 
+    public function testWarmsEveryBuildUnderItsOwnKey()
+    {
+        $warmer = new EntrypointsCacheWarmer(
+            [
+                '_default' => __DIR__.'/../fixtures/build/entrypoints.json',
+                'admin' => __DIR__.'/../fixtures/build/entrypoints.json',
+            ],
+            new PhpArrayAdapter($this->file, new ArrayAdapter()),
+        );
+        $warmer->warmUp(sys_get_temp_dir());
+
+        $cache = new PhpArrayAdapter($this->file, new ArrayAdapter());
+        $this->assertTrue($cache->getItem('reprise.entrypoints._default')->isHit());
+        $this->assertTrue($cache->getItem('reprise.entrypoints.admin')->isHit());
+    }
+
     public function testSkipsAMissingFileWithoutThrowing()
     {
         $cache = new PhpArrayAdapter($this->file, new ArrayAdapter());
-        $warmer = new EntrypointsCacheWarmer('/does/not/exist/entrypoints.json', 'reprise.entrypoints', $cache);
+        $warmer = new EntrypointsCacheWarmer(['_default' => '/does/not/exist/entrypoints.json'], $cache);
 
         $this->assertSame([], $warmer->warmUp(sys_get_temp_dir()));
-        $this->assertFalse($cache->getItem('reprise.entrypoints')->isHit());
+        $this->assertFalse($cache->getItem('reprise.entrypoints._default')->isHit());
     }
 
     public function testTheFullEntrypointsGraphSurvivesTheCompiledFileRoundTrip()

--- a/tests/EventListener/ResetAssetsEventListenerTest.php
+++ b/tests/EventListener/ResetAssetsEventListenerTest.php
@@ -25,9 +25,12 @@ use Symfony\Reprise\Asset\EntrypointsLookup;
 use Symfony\Reprise\Asset\EntrypointsLookupInterface;
 use Symfony\Reprise\Asset\TagRenderer;
 use Symfony\Reprise\EventListener\ResetAssetsEventListener;
+use Symfony\Reprise\Tests\BuildCollectionTrait;
 
 final class ResetAssetsEventListenerTest extends TestCase
 {
+    use BuildCollectionTrait;
+
     private function lookup(string $fixture = 'build'): EntrypointsLookup
     {
         return new EntrypointsLookup(__DIR__.'/../fixtures/'.$fixture.'/entrypoints.json');
@@ -35,7 +38,10 @@ final class ResetAssetsEventListenerTest extends TestCase
 
     private function rendererFor(EntrypointsLookupInterface $lookup): TagRenderer
     {
-        return new TagRenderer($lookup, new Packages(new PathPackage('/', new EmptyVersionStrategy())));
+        return new TagRenderer(
+            $this->collection(['_default' => $lookup]),
+            new Packages(new PathPackage('/', new EmptyVersionStrategy())),
+        );
     }
 
     private function finishRequest(int $requestType): FinishRequestEvent
@@ -53,7 +59,7 @@ final class ResetAssetsEventListenerTest extends TestCase
         $lookup = $this->lookup();
         $lookup->getPreloadFiles('app'); // marks the shared chunk as already returned
 
-        new ResetAssetsEventListener($lookup, $this->rendererFor($lookup))->onFinishRequest($this->finishRequest(HttpKernelInterface::MAIN_REQUEST));
+        new ResetAssetsEventListener([$lookup, $this->rendererFor($lookup)])->onFinishRequest($this->finishRequest(HttpKernelInterface::MAIN_REQUEST));
 
         // After the reset the shared chunk is offered again to the next request.
         $this->assertSame(['build/shared-e5f6.js'], $lookup->getPreloadFiles('admin'));
@@ -64,7 +70,7 @@ final class ResetAssetsEventListenerTest extends TestCase
         $lookup = $this->lookup();
         $lookup->getPreloadFiles('app');
 
-        new ResetAssetsEventListener($lookup, $this->rendererFor($lookup))->onFinishRequest($this->finishRequest(HttpKernelInterface::SUB_REQUEST));
+        new ResetAssetsEventListener([$lookup, $this->rendererFor($lookup)])->onFinishRequest($this->finishRequest(HttpKernelInterface::SUB_REQUEST));
 
         // A sub-request finishing must NOT reset -- the shared chunk stays deduplicated.
         $this->assertSame([], $lookup->getPreloadFiles('admin'));
@@ -75,7 +81,7 @@ final class ResetAssetsEventListenerTest extends TestCase
         $lookup = $this->lookup();
         $lookup->getPreloadFiles('app');
 
-        new ResetAssetsEventListener($lookup, $this->rendererFor($lookup))->onException($this->exceptionEvent(HttpKernelInterface::MAIN_REQUEST));
+        new ResetAssetsEventListener([$lookup, $this->rendererFor($lookup)])->onException($this->exceptionEvent(HttpKernelInterface::MAIN_REQUEST));
 
         $this->assertSame(['build/shared-e5f6.js'], $lookup->getPreloadFiles('admin'));
     }
@@ -86,7 +92,7 @@ final class ResetAssetsEventListenerTest extends TestCase
         $lookup = $this->lookup();
         $lookup->getPreloadFiles('app');
 
-        new ResetAssetsEventListener($lookup, $this->rendererFor($lookup))->onException($this->exceptionEvent(HttpKernelInterface::SUB_REQUEST));
+        new ResetAssetsEventListener([$lookup, $this->rendererFor($lookup)])->onException($this->exceptionEvent(HttpKernelInterface::SUB_REQUEST));
 
         $this->assertSame(['build/shared-e5f6.js'], $lookup->getPreloadFiles('admin'));
     }
@@ -98,7 +104,7 @@ final class ResetAssetsEventListenerTest extends TestCase
         $renderer->renderScriptTags('app');
         $this->assertStringNotContainsString('@vite/client', $renderer->renderScriptTags('app'), 'sanity: not re-injected within the same request');
 
-        new ResetAssetsEventListener($lookup, $renderer)->onException($this->exceptionEvent(HttpKernelInterface::MAIN_REQUEST));
+        new ResetAssetsEventListener([$lookup, $renderer])->onException($this->exceptionEvent(HttpKernelInterface::MAIN_REQUEST));
 
         $this->assertStringContainsString('@vite/client', $renderer->renderScriptTags('app'));
     }
@@ -109,7 +115,7 @@ final class ResetAssetsEventListenerTest extends TestCase
         $renderer = $this->rendererFor($lookup);
 
         $dispatcher = new EventDispatcher();
-        $dispatcher->addSubscriber(new ResetAssetsEventListener($lookup, $renderer));
+        $dispatcher->addSubscriber(new ResetAssetsEventListener([$lookup, $renderer]));
 
         // Symfony's ErrorListener renders the error page at priority -128; capture what it would emit.
         $errorPageTags = null;

--- a/tests/Functional/MultipleBuildsTest.php
+++ b/tests/Functional/MultipleBuildsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Tests\Functional;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Reprise\Asset\TagRenderer;
+use Symfony\Reprise\Exception\UndefinedBuildException;
+use Symfony\Reprise\Tests\Kernel\FunctionalAppKernel;
+
+final class MultipleBuildsTest extends TestCase
+{
+    private function renderer(): TagRenderer
+    {
+        // Two builds with distinct dev servers -- the default injects an HMR client, the "widget" one does not --
+        // to exercise per-build routing and independent client injection through the real container wiring.
+        $kernel = new FunctionalAppKernel(
+            __DIR__.'/../fixtures/dev',
+            ['builds' => ['widget' => __DIR__.'/../fixtures/dev-rspack']],
+        );
+        $kernel->boot();
+
+        return $kernel->getContainer()->get('reprise.tag_renderer');
+    }
+
+    public function testEachBuildRendersFromItsOwnEntrypointsAndDevServer()
+    {
+        $renderer = $this->renderer();
+
+        // The default build serves from :5173 and injects its HMR client once.
+        $this->assertSame(
+            '<script type="module" src="http://127.0.0.1:5173/build/@vite/client"></script>'
+            .'<script src="http://127.0.0.1:5173/build/app.js" type="module"></script>',
+            $renderer->renderScriptTags('app'),
+        );
+
+        // The widget build serves from :3000; its client is compiled in, so nothing is injected.
+        $this->assertSame(
+            '<script src="http://127.0.0.1:3000/build/app.js" type="module"></script>',
+            $renderer->renderScriptTags('app', build: 'widget'),
+        );
+    }
+
+    public function testEntryExistsIsResolvedPerBuild()
+    {
+        $renderer = $this->renderer();
+
+        $this->assertTrue($renderer->entryExists('app'));
+        $this->assertTrue($renderer->entryExists('app', build: 'widget'));
+    }
+
+    public function testRenderingAnUnconfiguredBuildThrows()
+    {
+        $this->expectException(UndefinedBuildException::class);
+
+        $this->renderer()->renderScriptTags('app', build: 'mobile');
+    }
+}

--- a/tests/RepriseBundleTest.php
+++ b/tests/RepriseBundleTest.php
@@ -46,4 +46,20 @@ final class RepriseBundleTest extends TestCase
 
         new FunctionalAppKernel(__DIR__.'/fixtures/build', ['crossorigin' => 'not-valid'])->boot();
     }
+
+    public function testRejectsTheReservedDefaultBuildName()
+    {
+        // "_default" is reserved for the output_path build, so it cannot be used as a named build.
+        $this->expectException(InvalidConfigurationException::class);
+
+        new FunctionalAppKernel(__DIR__.'/fixtures/build', ['builds' => ['_default' => __DIR__.'/fixtures/build']])->boot();
+    }
+
+    public function testRequiresAtLeastOneBuild()
+    {
+        // output_path: false with no named builds leaves nothing to look up.
+        $this->expectException(\LogicException::class);
+
+        new FunctionalAppKernel(__DIR__.'/fixtures/build', ['output_path' => false])->boot();
+    }
 }

--- a/tests/Twig/AssetExtensionTest.php
+++ b/tests/Twig/AssetExtensionTest.php
@@ -19,6 +19,7 @@ use Symfony\Reprise\Asset\DevServer;
 use Symfony\Reprise\Asset\EntrypointsLookup;
 use Symfony\Reprise\Asset\EntrypointsLookupInterface;
 use Symfony\Reprise\Asset\TagRenderer;
+use Symfony\Reprise\Tests\BuildCollectionTrait;
 use Symfony\Reprise\Twig\AssetExtension;
 use Symfony\Reprise\Twig\AssetRuntime;
 use Twig\Environment;
@@ -27,6 +28,8 @@ use Twig\RuntimeLoader\FactoryRuntimeLoader;
 
 final class AssetExtensionTest extends TestCase
 {
+    use BuildCollectionTrait;
+
     public function testFunctionsRenderThroughALazilyBuiltRuntime()
     {
         $built = 0;
@@ -92,13 +95,14 @@ final class AssetExtensionTest extends TestCase
 
     public function testEntryExistsFunctionReflectsTheLookup()
     {
+        $collection = $this->collection(['_default' => new EntrypointsLookup(__DIR__.'/../fixtures/build/entrypoints.json')]);
         $twig = new Environment(new ArrayLoader([
             'page' => "{{ reprise_entry_exists('app') ? 'yes' : 'no' }}|{{ reprise_entry_exists('missing') ? 'yes' : 'no' }}",
         ]));
         $twig->addExtension(new AssetExtension());
         $twig->addRuntimeLoader(new FactoryRuntimeLoader([
             AssetRuntime::class => static fn (): AssetRuntime => new AssetRuntime(new TagRenderer(
-                new EntrypointsLookup(__DIR__.'/../fixtures/build/entrypoints.json'),
+                $collection,
                 new Packages(new PathPackage('/', new EmptyVersionStrategy())),
             )),
         ]));
@@ -166,6 +170,9 @@ final class AssetExtensionTest extends TestCase
             }
         };
 
-        return new TagRenderer($lookup, new Packages(new PathPackage('/', new EmptyVersionStrategy())));
+        return new TagRenderer(
+            $this->collection(['_default' => $lookup]),
+            new Packages(new PathPackage('/', new EmptyVersionStrategy())),
+        );
     }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | yes
| License        | MIT

This is Reprise's port of Webpack Encore's multi-build feature (Encore's `builds` config plus the `entrypointName` argument on tag functions). A single Symfony app can now drive several independent bundles at once: for example, a Vite-built public frontend and an Rsbuild-built admin panel, each with its own plugin config, output directory, and `entrypoints.json`. The default build continues to come from `output_path`; named builds are declared under a new `builds` key (a map of build name -> output directory). Setting `output_path: false` enables a named-builds-only setup, provided at least one build is declared (the bundle throws at container-compile time otherwise). The name `_default` is reserved.

Every Twig tag and file function (`reprise_entry_script_tags`, `reprise_entry_link_tags`, `reprise_entry_js_files`, `reprise_entry_css_files`) and `reprise_entry_exists` now accepts a `build` argument to select which build to look up; omitting it falls back to the default.

```twig
{{ reprise_entry_script_tags('app') }}
{{ reprise_entry_script_tags('dashboard', build='admin') }}
```

A few internals worth flagging for review: there is a new `EntrypointsLookupCollection` (backed by a service locator, behind a public `EntrypointsLookupCollectionInterface`) that resolves the per-build `EntrypointsLookup` service on demand, and a new `UndefinedBuildException` for unknown build names. The `TagRenderer` now resolves its lookup through that collection and tracks injected HMR clients as a set keyed by client URL, so two dev servers running simultaneously (Vite and Rsbuild) each inject their client exactly once. The reset listener was generalized to reset an `iterable<ResetInterface>` covering every build's lookup plus the renderer, and the cache warmer now warms one cache key per build. The `build` argument on Twig functions, previously introduced as a reserved placeholder that threw on use, is now fully functional.

No JS or plugin changes are needed: one bundler config already writes one `entrypoints.json` per output directory. The feature is covered by unit tests, a Vite+Rsbuild functional test, and config-validation tests, and documented in `doc/index.rst`.
