### PR TITLE
[Tests][CI] Add end-to-end playground tests with Vitest and Playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,98 @@ jobs:
             - name: PHPUnit
               run: vendor/bin/phpunit
 
+    e2e:
+        name: E2E ${{ matrix.name }}
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - {
+                          name: 'Vite 7 · Symfony 7.4',
+                          id: vite7-sf74,
+                          symfony-version: 7.4.*,
+                          bundler: vite,
+                          add: 'vite@^7 @vitejs/plugin-react@^5',
+                      }
+                    - {
+                          name: 'Vite 7 · Symfony 8.1',
+                          id: vite7-sf81,
+                          symfony-version: 8.1.*,
+                          bundler: vite,
+                          add: 'vite@^7 @vitejs/plugin-react@^5',
+                      }
+                    - {
+                          name: 'Vite 8 · Symfony 7.4',
+                          id: vite8-sf74,
+                          symfony-version: 7.4.*,
+                          bundler: vite,
+                          add: 'vite@^8',
+                      }
+                    - {
+                          name: 'Vite 8 · Symfony 8.1',
+                          id: vite8-sf81,
+                          symfony-version: 8.1.*,
+                          bundler: vite,
+                          add: 'vite@^8',
+                      }
+                    - { name: 'Rsbuild · Symfony 7.4', id: rsbuild-sf74, symfony-version: 7.4.*, bundler: rsbuild }
+                    - { name: 'Rsbuild · Symfony 8.1', id: rsbuild-sf81, symfony-version: 8.1.*, bundler: rsbuild }
+        env:
+            # symfony/flex forces every symfony/* package to this line during the Composer resolution.
+            SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
+            E2E_BUNDLER: ${{ matrix.bundler }}
+            E2E_ARTIFACTS: '1'
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  persist-credentials: false
+            - name: Setup PHP
+              uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+              with:
+                  php-version: '8.4'
+                  tools: flex, symfony-cli
+            - name: Install PHP dependencies
+              uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+              with:
+                  working-directory: playground
+                  dependency-versions: highest
+                  composer-options: --prefer-dist
+                  custom-cache-suffix: ${{ matrix.symfony-version }}
+            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+            - name: Set node
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  node-version-file: .nvmrc
+                  cache: pnpm
+                  cache-dependency-path: pnpm-lock.yaml
+            - name: Install JS dependencies
+              run: pnpm install --frozen-lockfile
+            - name: Pin ${{ matrix.name }}
+              if: matrix.add
+              run: pnpm -C playground add -D ${{ matrix.add }}
+            - name: Build Reprise
+              run: pnpm build
+            - name: Cache Playwright browsers
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: playwright-${{ hashFiles('pnpm-lock.yaml') }}
+            - name: Install Playwright Chromium
+              run: pnpm -C playground exec playwright install --with-deps chromium
+            - name: E2E
+              run: pnpm -C playground run test:e2e
+            - name: Upload Playwright artifacts
+              if: failure()
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: e2e-artifacts-${{ matrix.id }}
+                  path: playground/tests/e2e/artifacts/
+                  if-no-files-found: ignore
+                  retention-days: 7
+
     php-qa:
         runs-on: ubuntu-latest
         permissions:

--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -1,4 +1,5 @@
 composer.lock
+/tests/e2e/artifacts/
 
 ###> symfony/framework-bundle ###
 /.env.local

--- a/playground/assets/demos/confetti.ts
+++ b/playground/assets/demos/confetti.ts
@@ -3,6 +3,7 @@ const COLORS = ['#10b981', '#f59e0b', '#ef4444', '#3b82f6', '#a855f7']
 export function celebrate(): void {
     for (let i = 0; i < 90; i++) {
         const piece = document.createElement('div')
+        piece.dataset.confettiPiece = ''
         piece.style.cssText = `position:fixed;top:-12px;left:${(i * 53) % 100}vw;width:9px;height:9px;`
             + `background:${COLORS[i % COLORS.length]};z-index:9999;pointer-events:none;border-radius:2px`
         document.body.appendChild(piece)

--- a/playground/package.json
+++ b/playground/package.json
@@ -5,7 +5,8 @@
     "vite:dev": "vite",
     "vite:build": "vite build",
     "rsbuild:dev": "rsbuild dev",
-    "rsbuild:build": "rsbuild build"
+    "rsbuild:build": "rsbuild build",
+    "test:e2e": "vitest run"
   },
   "dependencies": {
     "@hotwired/stimulus": "^3.0.0",
@@ -39,9 +40,12 @@
     "@tailwindcss/vite": "^4.3.3",
     "@vitejs/plugin-react": "^4.3.0",
     "@vitejs/plugin-vue": "^6.0.0",
+    "playwright": "^1.62.1",
     "sass-embedded": "^1.100.0",
     "tailwindcss": "^4.3.3",
+    "unplugin": "^3.3.0",
     "vite": "^8.1.3",
-    "vite-plugin-inspect": "^12.0.0-beta.3"
+    "vite-plugin-inspect": "^12.0.0-beta.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/playground/templates/components/Counter.html.twig
+++ b/playground/templates/components/Counter.html.twig
@@ -1,5 +1,5 @@
 <div{{ attributes }} class="flex items-center gap-4 rounded-xl border border-slate-200 bg-white p-5">
     <twig:Button data-action="live#action" data-live-action-param="decrement">−</twig:Button>
-    <strong class="min-w-[2ch] text-center text-2xl">{{ count }}</strong>
+    <strong data-testid="counter-value" class="min-w-[2ch] text-center text-2xl">{{ count }}</strong>
     <twig:Button data-action="live#action" data-live-action-param="increment">+</twig:Button>
 </div>

--- a/playground/tests/e2e/global-setup.ts
+++ b/playground/tests/e2e/global-setup.ts
@@ -1,0 +1,70 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { setTimeout as sleep } from 'node:timers/promises'
+import type { GlobalSetupContext } from 'vitest/node'
+
+const e2eDir = dirname(fileURLToPath(import.meta.url))
+const playgroundDir = resolve(e2eDir, '..', '..')
+const repoRoot = resolve(playgroundDir, '..')
+
+const BUNDLER = process.env.E2E_BUNDLER === 'rsbuild' ? 'rsbuild' : 'vite'
+const PORT = process.env.E2E_PORT ?? '8099'
+
+function runQuiet(cmd: string, args: string[]): void {
+  try {
+    execFileSync(cmd, args, { cwd: playgroundDir, stdio: 'ignore' })
+  } catch {
+    // best effort (e.g. stopping a server that isn't running)
+  }
+}
+
+export default async function setup({ provide }: GlobalSetupContext) {
+  // Point the suite at an already-running server (e.g. a local dev server) and skip build + serve.
+  const external = process.env.E2E_BASE_URL
+  if (external) {
+    provide('baseURL', external)
+    return
+  }
+
+  if (!existsSync(resolve(repoRoot, 'assets/dist/index.mjs'))) {
+    throw new Error('Reprise is not built — run `pnpm build` at the repo root before the E2E tests.')
+  }
+
+  if (!process.env.E2E_SKIP_BUILD) {
+    // Vitest sets NODE_ENV=test; force production so the bundlers emit a real production build
+    // (otherwise Rsbuild leaves `process.env.NODE_ENV` unreplaced and the app throws at runtime).
+    execFileSync('pnpm', ['run', `${BUNDLER}:build`], {
+      cwd: playgroundDir,
+      stdio: 'inherit',
+      env: { ...process.env, NODE_ENV: 'production' },
+    })
+  }
+
+  // Serve the built app with the Symfony CLI over plain HTTP (no local CA needed in CI).
+  runQuiet('symfony', ['server:stop'])
+  execFileSync('symfony', ['server:start', '-d', '--no-tls', `--port=${PORT}`], {
+    cwd: playgroundDir,
+    stdio: 'inherit',
+  })
+
+  const baseURL = `http://127.0.0.1:${PORT}`
+  const stop = () => runQuiet('symfony', ['server:stop'])
+  const deadline = Date.now() + 30_000
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(baseURL + '/')
+      if (res.status < 500) {
+        provide('baseURL', baseURL)
+        return stop
+      }
+    } catch {
+      // server still booting
+    }
+    await sleep(500)
+  }
+
+  stop()
+  throw new Error(`Symfony server did not answer on ${baseURL} within 30s.`)
+}

--- a/playground/tests/e2e/interactions.test.ts
+++ b/playground/tests/e2e/interactions.test.ts
@@ -1,0 +1,141 @@
+import { type Browser, chromium } from 'playwright'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { expectNoErrors, withPage } from './support'
+
+let browser: Browser
+
+beforeAll(async () => {
+  browser = await chromium.launch()
+})
+
+afterAll(async () => {
+  await browser?.close()
+})
+
+describe('interactive demos react to input', () => {
+  test.each([
+    ['React', 'react'],
+    ['Vue', 'vue'],
+  ])('UX %s contrast checker recomputes on colour change', async (_name, slug) => {
+    await withPage(browser, async ({ page }) => {
+      await page.goto(`/demo/${slug}`, { waitUntil: 'load' })
+      const colour = page.locator('input[type=color]').first()
+      await colour.waitFor({ state: 'visible' })
+      // Black on the default white background is exactly 21:1.
+      await colour.fill('#000000')
+      await page.getByText('21.00:1').waitFor({ timeout: 5_000 })
+    })
+  })
+
+  test('UX Chart.js paints a canvas', async () => {
+    await withPage(browser, async ({ page, errors }) => {
+      await page.goto('/demo/chartjs', { waitUntil: 'load' })
+      const canvas = page.locator('canvas').first()
+      await canvas.waitFor({ state: 'visible', timeout: 5_000 })
+      const box = await canvas.boundingBox()
+      expect(box?.width ?? 0).toBeGreaterThan(0)
+      expectNoErrors(errors)
+    })
+  })
+
+  test('UX Autocomplete enhances the select with Tom Select', async () => {
+    await withPage(browser, async ({ page, errors }) => {
+      await page.goto('/demo/autocomplete', { waitUntil: 'load' })
+      await page.locator('.ts-control').waitFor({ state: 'visible', timeout: 5_000 })
+      expectNoErrors(errors)
+    })
+  })
+
+  test('UX Translator renders JS messages and reacts to interaction', async () => {
+    await withPage(browser, async ({ page, errors }) => {
+      await page.goto('/demo/translator', { waitUntil: 'load' })
+      // The greeting target starts as "…" and is filled once the JS catalog is loaded.
+      await page.waitForFunction(
+        () => {
+          const text = document.querySelector('[data-translator-target="greeting"]')?.textContent?.trim()
+          return !!text && text !== '…'
+        },
+        undefined,
+        { timeout: 5_000 },
+      )
+
+      const before = await page.locator('[data-translator-target="apples"]').textContent()
+      await page.locator('[data-action="translator#more"]').click()
+      await page.waitForFunction(
+        (previous) => document.querySelector('[data-translator-target="apples"]')?.textContent !== previous,
+        before,
+        { timeout: 5_000 },
+      )
+      expectNoErrors(errors)
+    })
+  })
+
+  test('UX Live Component re-renders the counter from the server', async () => {
+    await withPage(browser, async ({ page, errors }) => {
+      await page.goto('/demo/live-component', { waitUntil: 'load' })
+      const count = page.getByTestId('counter-value')
+      await count.waitFor({ state: 'visible' })
+      const before = (await count.textContent())?.trim()
+
+      const [response] = await Promise.all([
+        page.waitForResponse((res) => res.url().includes('/_components/') && res.request().method() === 'POST'),
+        page.locator('[data-live-action-param="increment"]').click(),
+      ])
+      expect(response.status()).toBeLessThan(400)
+
+      await page.waitForFunction(
+        (previous) => document.querySelector('[data-testid="counter-value"]')?.textContent?.trim() !== previous,
+        before,
+        { timeout: 5_000 },
+      )
+      expectNoErrors(errors)
+    })
+  })
+
+  test('UX Turbo swaps a frame without a full reload', async () => {
+    await withPage(browser, async ({ page, errors }) => {
+      await page.goto('/demo/turbo', { waitUntil: 'load' })
+      await page.locator('a[data-turbo-frame="detail"]').first().waitFor({ state: 'visible' })
+
+      // Sentinel survives a frame swap but not a full page reload.
+      await page.evaluate(() => {
+        ;(window as unknown as { __probe: string }).__probe = 'kept'
+      })
+      await page.locator('a[data-turbo-frame="detail"]').first().click()
+      await page.waitForFunction(
+        () => {
+          const frame = document.querySelector('turbo-frame#detail')
+          return !!frame && !frame.textContent?.includes('Pick a bundler')
+        },
+        undefined,
+        { timeout: 5_000 },
+      )
+
+      expect(await page.evaluate(() => (window as unknown as { __probe?: string }).__probe)).toBe('kept')
+      expectNoErrors(errors)
+    })
+  })
+
+  test('Code splitting loads the confetti chunk on demand', async () => {
+    await withPage(browser, async ({ page, errors }) => {
+      // Chunk file names differ per bundler (Vite: confetti-<hash>.js, Rsbuild: async/<n>.js),
+      // so assert "a new /build script loads", not the name.
+      const buildScripts: string[] = []
+      page.on('request', (req) => {
+        if (/\/build\/.*\.js(\?|$)/.test(req.url())) buildScripts.push(req.url())
+      })
+
+      await page.goto('/feature/code-splitting', { waitUntil: 'load' })
+      await page.locator('[data-confetti]').waitFor({ state: 'visible' })
+      const before = buildScripts.length
+
+      await page.locator('[data-confetti]').click()
+
+      await expect.poll(() => buildScripts.length, { timeout: 5_000 }).toBeGreaterThan(before)
+      await page.waitForFunction(() => document.querySelectorAll('[data-confetti-piece]').length > 0, undefined, {
+        timeout: 2_000,
+      })
+      expectNoErrors(errors)
+    })
+  })
+})

--- a/playground/tests/e2e/pages.test.ts
+++ b/playground/tests/e2e/pages.test.ts
@@ -1,0 +1,28 @@
+import { type Browser, chromium } from 'playwright'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { ALL_ROUTES, expectNoErrors, withPage } from './support'
+
+let browser: Browser
+
+beforeAll(async () => {
+  browser = await chromium.launch()
+})
+
+afterAll(async () => {
+  await browser?.close()
+})
+
+describe('every page renders without errors', () => {
+  test.each(ALL_ROUTES)('%s renders cleanly', async (path) => {
+    await withPage(browser, async ({ page, errors }) => {
+      const response = await page.goto(path, { waitUntil: 'load' })
+      expect(response?.status(), `navigation to ${path}`).toBeLessThan(400)
+
+      await page.locator('h1').first().waitFor({ state: 'visible', timeout: 10_000 })
+      // Let deferred JS (Stimulus connect, lazy controllers, component mount) run so it can surface late errors.
+      await page.waitForTimeout(800)
+
+      expectNoErrors(errors)
+    })
+  })
+})

--- a/playground/tests/e2e/support.ts
+++ b/playground/tests/e2e/support.ts
@@ -1,0 +1,122 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { Browser, BrowserContext, Page } from 'playwright'
+import { expect, inject } from 'vitest'
+
+declare module 'vitest' {
+  interface ProvidedContext {
+    baseURL: string
+  }
+}
+
+// With E2E_ARTIFACTS set, every context records a video; a failing test also dumps a screenshot and its
+// full console transcript into tests/e2e/artifacts/ (kept only for failures). CI uploads that directory.
+const ARTIFACTS = !!process.env.E2E_ARTIFACTS
+const ARTIFACT_DIR = join(dirname(fileURLToPath(import.meta.url)), 'artifacts')
+
+let seq = 0
+function artifactName(): string {
+  const name = expect.getState().currentTestName ?? ''
+  return name.replace(/[^a-z0-9]+/gi, '-').replace(/^-+|-+$/g, '').toLowerCase() || `test-${++seq}`
+}
+
+// Every routable page in the playground (mirrors src/Demo/DemoCatalog.php).
+export const ALL_ROUTES: string[] = [
+  '/',
+  '/admin',
+  '/feature/code-splitting',
+  '/feature/scss-typescript',
+  '/feature/copied-files',
+  '/feature/build-contract',
+  '/demo/react',
+  '/demo/vue',
+  '/demo/chartjs',
+  '/demo/autocomplete',
+  '/demo/dropzone',
+  '/demo/cropperjs',
+  '/demo/map',
+  '/demo/icons',
+  '/demo/translator',
+  '/demo/live-component',
+  '/demo/turbo',
+]
+
+export interface PageErrors {
+  console: string[]
+  pageErrors: string[]
+  http: string[]
+}
+
+export interface PageProbe {
+  context: BrowserContext
+  page: Page
+  errors: PageErrors
+  log: string[]
+}
+
+async function openPage(browser: Browser): Promise<PageProbe> {
+  const base = inject('baseURL')
+  const origin = new URL(base).origin
+  const context = await browser.newContext({
+    baseURL: base,
+    ignoreHTTPSErrors: true,
+    ...(ARTIFACTS ? { recordVideo: { dir: ARTIFACT_DIR } } : {}),
+  })
+  const page = await context.newPage()
+  const errors: PageErrors = { console: [], pageErrors: [], http: [] }
+  const log: string[] = []
+
+  page.on('console', (msg) => {
+    log.push(`[console:${msg.type()}] ${msg.text()}`)
+    if (msg.type() === 'error') errors.console.push(msg.text())
+  })
+  page.on('pageerror', (err) => {
+    log.push(`[pageerror] ${err.message}`)
+    errors.pageErrors.push(err.message)
+  })
+  page.on('response', (res) => {
+    const url = new URL(res.url())
+    // Only the app's own responses matter: skip third-party assets (map tiles, fonts), the favicon,
+    // and Symfony's reserved `/_*` routes (dev toolbar, profiler, fragments, live components).
+    if (url.origin !== origin) return
+    if (url.pathname === '/favicon.ico') return
+    if (url.pathname.startsWith('/_')) return
+    if (res.status() >= 400) {
+      log.push(`[response:${res.status()}] ${url.pathname}`)
+      errors.http.push(`${res.status()} ${url.pathname}`)
+    }
+  })
+
+  return { context, page, errors, log }
+}
+
+export async function withPage(browser: Browser, fn: (probe: PageProbe) => Promise<void>): Promise<void> {
+  const probe = await openPage(browser)
+  const label = artifactName()
+  let failed = false
+  try {
+    await fn(probe)
+  } catch (error) {
+    failed = true
+    if (ARTIFACTS) {
+      await mkdir(ARTIFACT_DIR, { recursive: true }).catch(() => {})
+      await probe.page.screenshot({ path: join(ARTIFACT_DIR, `${label}.png`), fullPage: true }).catch(() => {})
+      await writeFile(join(ARTIFACT_DIR, `${label}.log`), probe.log.join('\n'), 'utf8').catch(() => {})
+    }
+    throw error
+  } finally {
+    const video = probe.page.video()
+    await probe.context.close()
+    if (video) {
+      if (failed) await video.saveAs(join(ARTIFACT_DIR, `${label}.webm`)).catch(() => {})
+      await video.delete().catch(() => {})
+    }
+  }
+}
+
+export function expectNoErrors(errors: PageErrors): void {
+  expect(errors.pageErrors, 'uncaught JS exceptions').toEqual([])
+  expect(errors.console, 'console.error output').toEqual([])
+  expect(errors.http, 'same-origin HTTP >= 400 responses').toEqual([])
+}

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -13,7 +13,7 @@ const publicPath = process.env.CDN_BASE ?? '/build/'
 
 export default defineConfig({
   build: {
-    rolldownOptions: {
+    rollupOptions: {
       input: {
         app: resolve(__dirname, './assets/app.ts'),
         admin: resolve(__dirname, './assets/admin.ts'),

--- a/playground/vitest.config.ts
+++ b/playground/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['tests/e2e/**/*.test.ts'],
+    globalSetup: ['./tests/e2e/global-setup.ts'],
+    testTimeout: 30_000,
+    hookTimeout: 240_000,
+    // One Symfony server shared across files: keep the files from running in parallel.
+    fileParallelism: false,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,22 +147,31 @@ importers:
         version: 4.3.3(vite@8.1.3(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.39.2)(tsx@4.23.1)(yaml@2.9.0))
       '@vitejs/plugin-react':
         specifier: ^4.3.0
-        version: 4.7.0(vite@8.1.3(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.39.2)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.7.0(supports-color@5.5.0)(vite@8.1.3(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.39.2)(tsx@4.23.1)(yaml@2.9.0))
       '@vitejs/plugin-vue':
         specifier: ^6.0.0
         version: 6.0.8(vite@8.1.3(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.39.2)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      playwright:
+        specifier: ^1.62.1
+        version: 1.62.1
       sass-embedded:
         specifier: ^1.100.0
         version: 1.100.0
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
+      unplugin:
+        specifier: ^3.3.0
+        version: 3.3.0(@rspack/core@2.1.3(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.2.0)(vite@8.1.3(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.39.2)(tsx@4.23.1)(yaml@2.9.0))
       vite:
         specifier: ^8.1.3
         version: 8.1.3(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.39.2)(tsx@4.23.1)(yaml@2.9.0)
       vite-plugin-inspect:
         specifier: ^12.0.0-beta.3
         version: 12.0.0-beta.3(@rspack/core@2.1.3(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.2.0)(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.39.2)(tsx@4.23.1)(yaml@2.9.0))
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.3(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.39.2)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 
@@ -1953,6 +1962,11 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2276,6 +2290,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
@@ -2964,20 +2988,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7':
+  '@babel/core@7.29.7(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@5.5.0))
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@5.5.0)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3004,17 +3028,17 @@ snapshots:
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@5.5.0)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3035,14 +3059,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/template@7.29.7':
@@ -3051,7 +3075,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -3059,7 +3083,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3924,11 +3948,11 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@vitejs/plugin-react@4.7.0(vite@8.1.3(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.39.2)(tsx@4.23.1)(yaml@2.9.0))':
+  '@vitejs/plugin-react@4.7.0(supports-color@5.5.0)(vite@8.1.3(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.39.2)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@5.5.0)
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7(supports-color@5.5.0))
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7(supports-color@5.5.0))
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
@@ -4228,10 +4252,6 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.3(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -4352,6 +4372,9 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -4685,6 +4708,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.2
       pathe: 2.0.3
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.16:
     dependencies:


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

This PR adds end-to-end tests for the `playground/` app, the full Symfony app we use to manually verify the bundle against a real backend. The runner is Vitest driving Playwright (Chromium).

The suite covers all 17 playground routes: the dashboard, the feature pages, and every UX demo page. Each page is checked for a clean render (no console errors, no uncaught exceptions, no failing same-origin HTTP responses, page heading present). Beyond those baseline checks, the interactive demos are actually exercised: the React and Vue contrast-checker islands recompute on input, Chart.js paints its canvas, Autocomplete upgrades the select, the Translator renders its JS messages and reacts to a click, the Live Component re-renders from the server, a Turbo frame swaps without a full reload, and the code-split confetti chunk loads on demand.

A Vitest global setup builds the playground with the chosen bundler, then serves the built app through the Symfony CLI over plain HTTP. The bundler and Symfony version are selected by environment variables, which mirrors how the existing CI jobs pin versions. In CI, a new `e2e` matrix job runs the suite against Symfony 7.4 and 8.1, each with Vite 7, Vite 8, and Rsbuild (6 legs total). The Playwright browser download is cached, and on failure each affected test's screenshot, video, and console log are uploaded as a build artifact.

This PR also fixes a real problem the tests surfaced immediately. The playground only built on Vite 8 because its config used `build.rolldownOptions`, which is a Vite 8 (rolldown-vite) only option. Under Vite 7 the entries were never defined and the build failed. The fix is to use `build.rollupOptions` instead, which works on both Vite 7 and Vite 8. `unplugin` is also added as a direct dev dependency of the playground so Vite 7's config loader can resolve it.
