### PR TITLE
[Integrity] Fix missing `integrity` and `crossorigin` to preload `Link` headers

### DIFF
--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -75,7 +75,7 @@ final class TagRenderer implements ResetInterface
             $tagAttributes = ['rel' => 'modulepreload', 'href' => $url];
             $this->applyIntegrity($tagAttributes, $reference, $integrity);
             $tags[] = \sprintf('<link %s>', $this->attributes($tagAttributes));
-            $this->preload($url, 'modulepreload');
+            $this->preload($url, 'modulepreload', null, $reference, $integrity);
         }
 
         foreach ($lookup->getJavaScriptFiles($entryName) as $reference) {
@@ -83,7 +83,7 @@ final class TagRenderer implements ResetInterface
             $tagAttributes = ['src' => $url, 'type' => 'module'] + $attributes + $this->scriptAttributes;
             $this->applyIntegrity($tagAttributes, $reference, $integrity);
             $tags[] = \sprintf('<script %s></script>', $this->attributes($tagAttributes));
-            $this->preload($url, 'preload', 'script');
+            $this->preload($url, 'preload', 'script', $reference, $integrity);
         }
 
         return implode('', $tags);
@@ -103,7 +103,7 @@ final class TagRenderer implements ResetInterface
             $tagAttributes = ['rel' => 'stylesheet', 'href' => $url] + $attributes + $this->linkAttributes;
             $this->applyIntegrity($tagAttributes, $reference, $integrity);
             $tags[] = \sprintf('<link %s>', $this->attributes($tagAttributes));
-            $this->preload($url, 'preload', 'style');
+            $this->preload($url, 'preload', 'style', $reference, $integrity);
         }
 
         return implode('', $tags);
@@ -161,7 +161,10 @@ final class TagRenderer implements ResetInterface
         return $this->packages->getUrl($reference, $packageName ?? $this->defaultPackage);
     }
 
-    private function preload(string $url, string $rel, ?string $as = null): void
+    /**
+     * @param array<string, string> $integrity
+     */
+    private function preload(string $url, string $rel, ?string $as, string $reference, array $integrity): void
     {
         if (!$this->preload || null === $this->requestStack || !class_exists(GenericLinkProvider::class)) {
             return;
@@ -175,6 +178,11 @@ final class TagRenderer implements ResetInterface
         $link = new Link($rel, $url);
         if (null !== $as) {
             $link = $link->withAttribute('as', $as);
+        }
+        // Mirror the tag's SRI onto the preload, or the browser discards the preloaded response as a mismatch.
+        [$hash, $crossorigin] = $this->integrityFor($reference, $integrity);
+        if (null !== $hash) {
+            $link = $link->withAttribute('integrity', $hash)->withAttribute('crossorigin', $crossorigin);
         }
 
         $linkProvider = $request->attributes->get('_links');
@@ -190,11 +198,29 @@ final class TagRenderer implements ResetInterface
      */
     private function applyIntegrity(array &$attributes, string $reference, array $integrity): void
     {
-        if (!isset($integrity[$reference])) {
+        [$hash, $crossorigin] = $this->integrityFor($reference, $integrity);
+        if (null === $hash) {
             return;
         }
-        $attributes['integrity'] = $integrity[$reference];
-        $attributes['crossorigin'] = false === $this->crossorigin ? 'anonymous' : $this->crossorigin;
+        $attributes['integrity'] = $hash;
+        $attributes['crossorigin'] = $crossorigin;
+    }
+
+    /**
+     * Resolves the SRI hash + crossorigin for a reference, so a tag and its preload Link derive them
+     * from one place and can never drift.
+     *
+     * @param array<string, string> $integrity
+     *
+     * @return array{0: ?string, 1: string}
+     */
+    private function integrityFor(string $reference, array $integrity): array
+    {
+        if (!isset($integrity[$reference])) {
+            return [null, ''];
+        }
+
+        return [$integrity[$reference], false === $this->crossorigin ? 'anonymous' : $this->crossorigin];
     }
 
     /**

--- a/tests/Asset/TagRendererTest.php
+++ b/tests/Asset/TagRendererTest.php
@@ -279,6 +279,68 @@ final class TagRendererTest extends TestCase
         $this->assertSame('style', $byHref['/build/app-c3.css']['as']);
     }
 
+    public function testPreloadLinksCarryIntegrityAndCrossoriginWhenPresent()
+    {
+        $stack = new RequestStack();
+        $stack->push($request = new Request());
+
+        $renderer = $this->renderer(
+            js: ['build/app-a1b2.js'],
+            css: ['build/app-c3.css'],
+            preload: ['build/shared-e5.js'],
+            integrity: [
+                'build/app-a1b2.js' => 'sha384-JS',
+                'build/app-c3.css' => 'sha384-CSS',
+                'build/shared-e5.js' => 'sha384-SHARED',
+            ],
+            requestStack: $stack,
+        );
+        $renderer->renderScriptTags('app');
+        $renderer->renderLinkTags('app');
+
+        $byHref = [];
+        foreach ($request->attributes->get('_links')->getLinks() as $link) {
+            $byHref[$link->getHref()] = $link->getAttributes();
+        }
+
+        $this->assertSame('sha384-SHARED', $byHref['/build/shared-e5.js']['integrity']);
+        $this->assertSame('anonymous', $byHref['/build/shared-e5.js']['crossorigin']);
+        $this->assertSame('sha384-JS', $byHref['/build/app-a1b2.js']['integrity']);
+        $this->assertSame('anonymous', $byHref['/build/app-a1b2.js']['crossorigin']);
+        $this->assertSame('sha384-CSS', $byHref['/build/app-c3.css']['integrity']);
+        $this->assertSame('anonymous', $byHref['/build/app-c3.css']['crossorigin']);
+    }
+
+    public function testPreloadLinksHaveNoIntegrityWhenTheAssetIsNotHashed()
+    {
+        $stack = new RequestStack();
+        $stack->push($request = new Request());
+
+        $this->renderer(js: ['build/app-a1b2.js'], requestStack: $stack)->renderScriptTags('app');
+
+        foreach ($request->attributes->get('_links')->getLinks() as $link) {
+            $this->assertArrayNotHasKey('integrity', $link->getAttributes());
+            $this->assertArrayNotHasKey('crossorigin', $link->getAttributes());
+        }
+    }
+
+    public function testPreloadLinksUseTheConfiguredCrossorigin()
+    {
+        $stack = new RequestStack();
+        $stack->push($request = new Request());
+
+        $this->renderer(
+            js: ['build/app-a1b2.js'],
+            integrity: ['build/app-a1b2.js' => 'sha384-JS'],
+            crossorigin: 'use-credentials',
+            requestStack: $stack,
+        )->renderScriptTags('app');
+
+        foreach ($request->attributes->get('_links')->getLinks() as $link) {
+            $this->assertSame('use-credentials', $link->getAttributes()['crossorigin']);
+        }
+    }
+
     public function testDoesNotRegisterLinksWithoutACurrentRequest()
     {
         $renderer = $this->renderer(js: ['build/app-a1b2.js'], requestStack: new RequestStack());


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

When SRI is enabled, RepriseBundle pushes HTTP `Link:` preload headers (via symfony/web-link) for each entry's JS and CSS assets. Those headers were missing `integrity` and `crossorigin`, while the `<script>`/`<link>` tags rendered by the Twig helpers do carry both. The browser would preload the asset without CORS/SRI, then hit a tag that requires a CORS request with a matching integrity — so the preloaded response was thrown away and the asset fetched a second time. The browser console logged "A preload for ... is found, but is not used due to an integrity mismatch."

The fix attaches the same `integrity` and `crossorigin="anonymous"` to each preload `Link` header, matching what the tag will require, so the browser reuses the preload as intended. No behavior change when SRI is off. This mismatch was caught by the console-log capture introduced with the new playground end-to-end tests.
