### PR TITLE
[TagRenderer] Dispatch a `RenderAssetTagEvent` before rendering each tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.7.0
+
+- Add the `RenderAssetTagEvent`, dispatched before each rendered `<script>`/`<link>` (including the injected dev client and React preamble), so listeners can add, change or remove attributes such as a CSP nonce
+
 ## 0.6.0
 
 - Add a per-call `attributes` argument to the `reprise_entry_script_tags()` and `reprise_entry_link_tags()` Twig functions

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Symfony Reprise covers only the Symfony-side glue the bundlers leave out:
 - 🧩 **Symfony UX / Stimulus**: registers `controllers.json` and local controllers, eager or lazy
 - 🌐 **CDN support**: serve built assets from an absolute `publicPath`
 - 🛡️ **Subresource Integrity**: SRI hashes in `entrypoints.json`
+- 🔐 **Customizable tag attributes**: `RenderAssetTagEvent` lets listeners add, change or remove attributes on every rendered tag (e.g. a CSP nonce)
 
 Vite and Rsbuild already handle **Sass/Less/PostCSS**, **TypeScript**, **JSX/Vue/Svelte**, **code splitting**, **content hashing**, **source maps**, **minification** and **HMR** on their own, so Symfony Reprise does not reimplement any of that.
 

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": ">=8.4",
         "symfony/asset": "^7.4|^8.0",
+        "symfony/event-dispatcher-contracts": "^3",
         "twig/twig": "^3.0"
     },
     "require-dev": {

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -30,6 +30,7 @@ reimplement any of that. It covers only the Symfony-side glue the bundlers leave
 - **Symfony UX / Stimulus**: registers ``controllers.json`` and local controllers, eager or lazy
 - **CDN support**: serve built assets from an absolute ``publicPath``
 - **Subresource Integrity**: SRI hashes in ``entrypoints.json``
+- **Customizable tag attributes**: ``RenderAssetTagEvent`` lets listeners add, change or remove attributes on every rendered tag
 
 It generates the Encore-compatible ``entrypoints.json`` and ``manifest.json`` that ``RepriseBundle`` reads to render
 the ``<script>`` and ``<link>`` tags, wires up the native dev server, and turns your Stimulus controllers into a
@@ -170,6 +171,33 @@ project needs nothing beyond installing the bundle (see `Configuration`_ below f
 same whether Vite or Rsbuild produced ``entrypoints.json``, and there's nothing to configure for dev either: in dev
 ``reprise_entry_script_tags`` injects the Vite HMR client automatically, while under Rsbuild the client is compiled
 into the bundle.
+
+Customizing rendered tags
+-------------------------
+
+Before Reprise writes any ``<script>`` or ``<link>`` tag (entry files, CSS, and the dev-server tags it injects itself,
+like the Vite HMR client and the React Fast Refresh preamble), it dispatches a ``RenderAssetTagEvent``.
+A listener can read and mutate ``$event->attributes`` to add, change, or remove attributes on that tag.
+
+As one example, stamping a Content-Security-Policy nonce on every tag::
+
+    namespace App\EventListener;
+
+    use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+    use Symfony\Reprise\Event\RenderAssetTagEvent;
+
+    #[AsEventListener]
+    final class CspNonceListener
+    {
+        public function __construct(private NonceGenerator $nonceGenerator)
+        {
+        }
+
+        public function __invoke(RenderAssetTagEvent $event): void
+        {
+            $event->attributes['nonce'] = $this->nonceGenerator->getNonce();
+        }
+    }
 
 Features
 --------

--- a/docs/superpowers/plans/2026-08-06-render-asset-tag-event.md
+++ b/docs/superpowers/plans/2026-08-06-render-asset-tag-event.md
@@ -1,0 +1,654 @@
+# RenderAssetTagEvent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dispatch a `RenderAssetTagEvent` before every `<script>`/`<link>` Reprise renders — including the injected HMR client and the React Refresh preamble — so listeners can add/change/remove attributes such as a CSP `nonce`.
+
+**Architecture:** A new public `Symfony\Reprise\Event\RenderAssetTagEvent` (private `type`, public mutable `attributes`, `isScript()`/`isLink()`). `TagRenderer` gains a nullable `EventDispatcherInterface` and one private `tag()` helper that every user-facing tag flows through: it dispatches the event, reads back `attributes`, then renders. Config `script_attributes`/`link_attributes` and per-call `attributes` seed all script tags (files, client, preamble) — the "unified path". `modulepreload` links stay out of the event.
+
+**Tech Stack:** PHP 8.4, Symfony (asset + event-dispatcher-contracts in `require`, framework-bundle for tests), PHPUnit 13.
+
+## Global Constraints
+
+- PHP `>=8.4`; strict types match the rest of `src/` (readonly promoted props, `node:`-style discipline N/A here).
+- Commit messages: Symfony style `[Scope] Imperative subject`, subject line only (no body). Final squashed commit scope: `[TagRenderer]`.
+- Comments: zero by default; one short line only when the "why" is non-obvious. Applies to tests too.
+- Docs: this is a backend, bundler-agnostic feature — ship a **single PHP listener example**, not a Vite+Rsbuild pair; no JS/functional bundler test symmetry.
+- CHANGELOG: features only; one terse bullet under a new `## 0.7.0`.
+- Existing output must stay byte-identical when no listener is registered (regression guard = the existing `TagRendererTest` + `DevAssetTagsTest` staying green).
+- Declare `symfony/event-dispatcher-contracts` (`^3`) in `require` — it provides the type-hinted `EventDispatcherInterface` (honest: `symfony/event-dispatcher` is already used unconditionally by `ResetAssetsEventListener`). The concrete `event_dispatcher` **service** stays app-provided (framework-bundle): wire `service('event_dispatcher')->nullOnInvalid()` + nullable ctor arg + `if (null !== $this->eventDispatcher)` guard. **No `composer suggest` block.** (The bundle's broader missing runtime `require`s — http-kernel/config/DI/http-foundation/event-dispatcher/service-contracts — are a separate audit, out of this plan's scope.)
+
+---
+
+### Task 1: The `RenderAssetTagEvent` class
+
+**Files:**
+- Create: `src/Event/RenderAssetTagEvent.php`
+- Modify: `composer.json` (add `symfony/event-dispatcher-contracts` to `require`)
+
+**Interfaces:**
+- Produces: `Symfony\Reprise\Event\RenderAssetTagEvent` with `public const TYPE_SCRIPT = 'script'`, `public const TYPE_LINK = 'link'`, constructor `__construct(private readonly string $type, public array $attributes)`, methods `isScript(): bool`, `isLink(): bool`. `$attributes` is `array<string, bool|string>`, mutated in place by listeners.
+
+`symfony/event-dispatcher-contracts` provides `Symfony\Contracts\EventDispatcher\EventDispatcherInterface`, type-hinted by `TagRenderer` in Task 2. It goes in `require` (not `require-dev`): it is a genuine runtime interface dependency.
+
+- [ ] **Step 1: Add the composer dependency**
+
+In `composer.json`, add to the `require` block (after `"symfony/asset": "^7.4|^8.0",`):
+
+```json
+"symfony/event-dispatcher-contracts": "^3",
+```
+
+- [ ] **Step 2: Sync the lock file**
+
+Run: `composer update symfony/event-dispatcher-contracts --no-interaction`
+Expected: the package is recorded in `composer.lock` (it is likely already installed transitively via framework-bundle; this pins it as a direct dependency).
+
+- [ ] **Step 3: Create the event class**
+
+Create `src/Event/RenderAssetTagEvent.php`:
+
+```php
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Event;
+
+/**
+ * Dispatched each time a <script> or <link> tag is rendered, so listeners can add, change or
+ * remove attributes (e.g. a CSP nonce) before the tag is written. Covers the entry files, the
+ * CSS, and the dev-server tags Reprise injects itself (the HMR client and React preamble).
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class RenderAssetTagEvent
+{
+    public const TYPE_SCRIPT = 'script';
+    public const TYPE_LINK = 'link';
+
+    /**
+     * @param array<string, bool|string> $attributes mutable; add/change/remove entries directly
+     */
+    public function __construct(
+        private readonly string $type,
+        public array $attributes,
+    ) {
+    }
+
+    public function isScript(): bool
+    {
+        return self::TYPE_SCRIPT === $this->type;
+    }
+
+    public function isLink(): bool
+    {
+        return self::TYPE_LINK === $this->type;
+    }
+}
+```
+
+- [ ] **Step 4: Static analysis + style on the new file**
+
+Run: `vendor/bin/phpstan analyse src/Event/RenderAssetTagEvent.php` then `vendor/bin/php-cs-fixer fix src/Event/RenderAssetTagEvent.php`
+Expected: no PHPStan errors; file already conforms (no diff, or the header/spacing gets normalized).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Event/RenderAssetTagEvent.php composer.json composer.lock
+git commit -m "[TagRenderer] Add the RenderAssetTagEvent class"
+```
+
+---
+
+### Task 2: Route file tags through a dispatching `tag()` helper + wire the dispatcher
+
+**Files:**
+- Modify: `src/Asset/TagRenderer.php`
+- Modify: `src/RepriseBundle.php:148-160` (the `reprise.tag_renderer` definition)
+- Test: `tests/Asset/TagRendererTest.php`
+
+**Interfaces:**
+- Consumes: `RenderAssetTagEvent` (Task 1); `Symfony\Contracts\EventDispatcher\EventDispatcherInterface`.
+- Produces: `TagRenderer::__construct(..., ?EventDispatcherInterface $eventDispatcher = null)` — new **last** parameter; private `TagRenderer::tag(string $type, array $attributes, ?string $inlineBody = null): string`.
+
+- [ ] **Step 1: Update the test helper to accept a dispatcher**
+
+In `tests/Asset/TagRendererTest.php`, add the import and extend the `renderer()` helper signature + call:
+
+```php
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+```
+
+Add a parameter to `renderer()` (after `?Packages $packages = null`):
+
+```php
+        ?EventDispatcherInterface $eventDispatcher = null,
+```
+
+and pass it as the new last argument of the `new TagRenderer(...)` call (after `$linkAttributes,`):
+
+```php
+            $eventDispatcher,
+```
+
+- [ ] **Step 2: Write the failing test — a listener adds an attribute to a script tag**
+
+Add to `tests/Asset/TagRendererTest.php` (add `use Symfony\Component\EventDispatcher\EventDispatcher;` at the top):
+
+```php
+    public function testAListenerCanAddAnAttributeToAScriptTag()
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(RenderAssetTagEvent::class, static function (RenderAssetTagEvent $event): void {
+            $event->attributes['nonce'] = 'r4nd0m';
+        });
+
+        $html = $this->renderer(js: ['build/app.js'], eventDispatcher: $dispatcher)->renderScriptTags('app');
+
+        $this->assertSame('<script src="/build/app.js" type="module" nonce="r4nd0m"></script>', $html);
+    }
+```
+
+Add the import `use Symfony\Reprise\Event\RenderAssetTagEvent;` too.
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `pnpm exec true; vendor/bin/phpunit --filter testAListenerCanAddAnAttributeToAScriptTag`
+Expected: FAIL — the dispatcher is never called (no `nonce` in the output).
+
+- [ ] **Step 4: Add the constructor arg + `tag()` helper, route JS/CSS through it**
+
+In `src/Asset/TagRenderer.php`:
+
+Add imports:
+
+```php
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Reprise\Event\RenderAssetTagEvent;
+```
+
+Add the constructor parameter as the **last** one (after `array $linkAttributes = []`):
+
+```php
+        private readonly ?EventDispatcherInterface $eventDispatcher = null,
+```
+
+Add the private helper (e.g. just above `attributes()`):
+
+```php
+    /**
+     * @param array<string, bool|string> $attributes
+     */
+    private function tag(string $type, array $attributes, ?string $inlineBody = null): string
+    {
+        if (null !== $this->eventDispatcher) {
+            $event = $this->eventDispatcher->dispatch(new RenderAssetTagEvent($type, $attributes));
+            $attributes = $event->attributes;
+        }
+
+        if (RenderAssetTagEvent::TYPE_LINK === $type) {
+            return \sprintf('<link %s>', $this->attributes($attributes));
+        }
+
+        return \sprintf('<script %s>%s</script>', $this->attributes($attributes), $inlineBody ?? '');
+    }
+```
+
+In `renderScriptTags()`, replace the JS-files loop body line that builds the tag:
+
+```php
+            $tags[] = \sprintf('<script %s></script>', $this->attributes($tagAttributes));
+```
+
+with:
+
+```php
+            $tags[] = $this->tag(RenderAssetTagEvent::TYPE_SCRIPT, $tagAttributes);
+```
+
+In `renderLinkTags()`, replace:
+
+```php
+            $tags[] = \sprintf('<link %s>', $this->attributes($tagAttributes));
+```
+
+with:
+
+```php
+            $tags[] = $this->tag(RenderAssetTagEvent::TYPE_LINK, $tagAttributes);
+```
+
+Leave the `modulepreload` loop's `\sprintf('<link %s>', $this->attributes($tagAttributes))` untouched.
+
+- [ ] **Step 5: Run the new test + the full TagRenderer suite**
+
+Run: `vendor/bin/phpunit tests/Asset/TagRendererTest.php`
+Expected: the new test PASSES and every existing test still PASSES (byte-identical output when no dispatcher is passed).
+
+- [ ] **Step 6: Wire the dispatcher in the bundle**
+
+In `src/RepriseBundle.php`, in the `reprise.tag_renderer` `->args([...])`, add as the **last** argument (after `$config['link_attributes'],`):
+
+```php
+                service('event_dispatcher')->nullOnInvalid(),
+```
+
+`->nullOnInvalid()` guards the concrete **service** (registered by the app, not by the contracts package from Task 1): if no `event_dispatcher` service exists, `null` is injected and the `tag()` guard skips dispatch. (`service` and `->nullOnInvalid()` come from `Symfony\Component\DependencyInjection\Loader\Configurator` — `service` is already imported at the top of the file.)
+
+- [ ] **Step 7: Run the bundle boot tests**
+
+Run: `vendor/bin/phpunit tests/RepriseBundleTest.php tests/Functional/DevAssetTagsTest.php tests/Functional/AssetTagsTest.php`
+Expected: PASS — the container compiles with the new argument, and the dev/build functional exact-match tests are unchanged (no listener → identical output).
+
+- [ ] **Step 8: Static analysis + style**
+
+Run: `vendor/bin/phpstan analyse` then `vendor/bin/php-cs-fixer fix src/Asset/TagRenderer.php src/RepriseBundle.php`
+Expected: no PHPStan errors; style clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Asset/TagRenderer.php src/RepriseBundle.php tests/Asset/TagRendererTest.php
+git commit -m "[TagRenderer] Route asset tags through a dispatched RenderAssetTagEvent"
+```
+
+---
+
+### Task 3: Apply the event to the injected HMR client and the React preamble
+
+**Files:**
+- Modify: `src/Asset/TagRenderer.php` (the dev-server block in `renderScriptTags()`, and `renderReactRefreshPreamble()`)
+- Test: `tests/Asset/TagRendererTest.php`
+
+**Interfaces:**
+- Consumes: `TagRenderer::tag()` (Task 2).
+- Produces: `TagRenderer::reactRefreshPreamble(string $reactRefreshUrl): string` (renamed from `renderReactRefreshPreamble`, now returns the **inner JS body only**).
+
+- [ ] **Step 1: Write the failing tests — event reaches the client, preamble, css; type reported; attr removal; modulepreload excluded; leak test inverted**
+
+In `tests/Asset/TagRendererTest.php`, **replace** the existing `testPerCallAttributesDoNotLeakIntoTheHmrClient` method entirely with:
+
+```php
+    public function testPerCallAttributesApplyToTheHmrClient()
+    {
+        // Unified path: per-call attributes now seed the injected client too (issue #71).
+        $html = $this->renderer(
+            js: ['http://127.0.0.1:5173/build/app.js'],
+            devServer: new DevServer('http://127.0.0.1:5173', 'http://127.0.0.1:5173/build/@vite/client'),
+        )->renderScriptTags('app', attributes: ['defer' => true]);
+
+        $this->assertStringContainsString('<script type="module" src="http://127.0.0.1:5173/build/@vite/client" defer></script>', $html);
+        $this->assertStringContainsString('src="http://127.0.0.1:5173/build/app.js" type="module" defer></script>', $html);
+    }
+```
+
+Then add these new tests:
+
+```php
+    public function testAListenerCanAddAnAttributeToEveryRenderedTag()
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(RenderAssetTagEvent::class, static function (RenderAssetTagEvent $event): void {
+            $event->attributes['nonce'] = 'r4nd0m';
+        });
+
+        $renderer = $this->renderer(
+            js: ['http://127.0.0.1:5173/build/app.js'],
+            css: ['build/app.css'],
+            devServer: new DevServer(
+                'http://127.0.0.1:5173',
+                'http://127.0.0.1:5173/build/@vite/client',
+                'http://127.0.0.1:5173/build/@react-refresh',
+            ),
+            eventDispatcher: $dispatcher,
+        );
+
+        $scripts = $renderer->renderScriptTags('app');
+        $links = $renderer->renderLinkTags('app');
+
+        $this->assertStringContainsString('<script type="module" src="http://127.0.0.1:5173/build/@vite/client" nonce="r4nd0m"></script>', $scripts);
+        $this->assertStringContainsString('<script type="module" nonce="r4nd0m">', $scripts); // the preamble
+        $this->assertStringContainsString('src="http://127.0.0.1:5173/build/app.js" type="module" nonce="r4nd0m"></script>', $scripts);
+        $this->assertStringContainsString('<link rel="stylesheet" href="/build/app.css" nonce="r4nd0m">', $links);
+    }
+
+    public function testTheEventReportsScriptOrLinkToTheListener()
+    {
+        $types = [];
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(RenderAssetTagEvent::class, static function (RenderAssetTagEvent $event) use (&$types): void {
+            $types[] = $event->isScript() ? 'script' : ($event->isLink() ? 'link' : 'other');
+        });
+
+        $renderer = $this->renderer(js: ['build/app.js'], css: ['build/app.css'], eventDispatcher: $dispatcher);
+        $renderer->renderScriptTags('app');
+        $renderer->renderLinkTags('app');
+
+        $this->assertSame(['script', 'link'], $types);
+    }
+
+    public function testAListenerCanRemoveAConfiguredAttribute()
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(RenderAssetTagEvent::class, static function (RenderAssetTagEvent $event): void {
+            unset($event->attributes['defer']);
+        });
+
+        $html = $this->renderer(js: ['build/app.js'], scriptAttributes: ['defer' => true], eventDispatcher: $dispatcher)
+            ->renderScriptTags('app');
+
+        $this->assertSame('<script src="/build/app.js" type="module"></script>', $html);
+    }
+
+    public function testModulepreloadLinksAreNotDispatchedToListeners()
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(RenderAssetTagEvent::class, static function (RenderAssetTagEvent $event): void {
+            $event->attributes['nonce'] = 'r4nd0m';
+        });
+
+        $html = $this->renderer(js: ['build/app.js'], preload: ['build/shared.js'], eventDispatcher: $dispatcher)
+            ->renderScriptTags('app');
+
+        // The modulepreload link never reaches a listener; only the <script> carries the nonce.
+        $this->assertStringContainsString('<link rel="modulepreload" href="/build/shared.js">', $html);
+        $this->assertStringContainsString('<script src="/build/app.js" type="module" nonce="r4nd0m"></script>', $html);
+    }
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `vendor/bin/phpunit tests/Asset/TagRendererTest.php --filter 'testPerCallAttributesApplyToTheHmrClient|testAListenerCanAddAnAttributeToEveryRenderedTag|testTheEventReportsScriptOrLinkToTheListener|testAListenerCanRemoveAConfiguredAttribute|testModulepreloadLinksAreNotDispatchedToListeners'`
+Expected: FAIL — the client/preamble are still emitted with the old raw `sprintf` (no per-call attrs, no event), so the nonce/`defer` do not appear on them and the preamble is not dispatched.
+
+- [ ] **Step 3: Route the client + preamble through `tag()`; split out the preamble body**
+
+In `src/Asset/TagRenderer.php`, replace the dev-server block in `renderScriptTags()`:
+
+```php
+        $devServer = $lookup->getDevServer();
+        if (null !== $devServer && null !== $devServer->client && !isset($this->injectedClients[$devServer->client])) {
+            $tags[] = \sprintf('<script type="module" src="%s"></script>', htmlspecialchars($devServer->client, \ENT_QUOTES));
+            if (null !== $devServer->reactRefresh) {
+                $tags[] = $this->renderReactRefreshPreamble($devServer->reactRefresh);
+            }
+            $this->injectedClients[$devServer->client] = true;
+        }
+```
+
+with:
+
+```php
+        $devServer = $lookup->getDevServer();
+        if (null !== $devServer && null !== $devServer->client && !isset($this->injectedClients[$devServer->client])) {
+            $clientAttributes = ['type' => 'module', 'src' => $devServer->client] + $attributes + $this->scriptAttributes;
+            $tags[] = $this->tag(RenderAssetTagEvent::TYPE_SCRIPT, $clientAttributes);
+            if (null !== $devServer->reactRefresh) {
+                $preambleAttributes = ['type' => 'module'] + $attributes + $this->scriptAttributes;
+                $tags[] = $this->tag(RenderAssetTagEvent::TYPE_SCRIPT, $preambleAttributes, $this->reactRefreshPreamble($devServer->reactRefresh));
+            }
+            $this->injectedClients[$devServer->client] = true;
+        }
+```
+
+Then replace the whole `renderReactRefreshPreamble()` method:
+
+```php
+    private function renderReactRefreshPreamble(string $reactRefreshUrl): string
+    {
+        return \sprintf(
+            <<<'HTML'
+                <script type="module">
+                import RefreshRuntime from "%s";
+                RefreshRuntime.injectIntoGlobalHook(window);
+                window.$RefreshReg$ = () => {};
+                window.$RefreshSig$ = () => (type) => type;
+                window.__vite_plugin_react_preamble_installed__ = true;
+                </script>
+                HTML,
+            htmlspecialchars($reactRefreshUrl, \ENT_QUOTES),
+        );
+    }
+```
+
+with one that returns only the inner JS body (leading + trailing newline so the wrapped output stays byte-identical, and the doc comment kept):
+
+```php
+    /**
+     * The inner body of Vite's React Fast Refresh preamble. `@vitejs/plugin-react` normally injects this
+     * into the HTML itself, but cannot when Symfony renders the page (backend integration), so we render
+     * it here before the entry, wrapped in a <script type="module"> by tag(). See
+     * https://vite.dev/guide/backend-integration.
+     */
+    private function reactRefreshPreamble(string $reactRefreshUrl): string
+    {
+        return \sprintf(
+            <<<'JS'
+
+                import RefreshRuntime from "%s";
+                RefreshRuntime.injectIntoGlobalHook(window);
+                window.$RefreshReg$ = () => {};
+                window.$RefreshSig$ = () => (type) => type;
+                window.__vite_plugin_react_preamble_installed__ = true;
+
+                JS,
+            htmlspecialchars($reactRefreshUrl, \ENT_QUOTES),
+        );
+    }
+```
+
+(The blank first and last lines inside the heredoc become the leading/trailing `\n`, so `tag()` produces `<script type="module">\nimport …true;\n</script>` — identical to today when no listener runs.)
+
+- [ ] **Step 4: Run the new tests + the full suite**
+
+Run: `vendor/bin/phpunit tests/Asset/TagRendererTest.php`
+Expected: all the new tests PASS, and the pre-existing dev tests (`testInjectsViteHmrClientOncePerRequestInDev`, `testInjectsReactRefreshPreambleAfterTheClientAndBeforeTheEntryInDev`, `testDoesNotInjectReactRefreshPreambleWhenNotAReactApp`, `testInjectsEachBuildsHmrClientOncePerRequest`) still PASS unchanged.
+
+- [ ] **Step 5: Run the functional dev suite (byte-identical guard)**
+
+Run: `vendor/bin/phpunit tests/Functional/DevAssetTagsTest.php`
+Expected: PASS — the injected client's exact HTML is unchanged (no listener registered in that kernel path).
+
+- [ ] **Step 6: Static analysis + style**
+
+Run: `vendor/bin/phpstan analyse` then `vendor/bin/php-cs-fixer fix src/Asset/TagRenderer.php`
+Expected: no errors; style clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Asset/TagRenderer.php tests/Asset/TagRendererTest.php
+git commit -m "[TagRenderer] Dispatch the event for the injected client and preamble"
+```
+
+---
+
+### Task 4: End-to-end integration test through the container
+
+**Files:**
+- Modify: `tests/Kernel/FunctionalAppKernel.php:73-86` (expose `event_dispatcher` publicly for the test)
+- Test: `tests/Functional/DevAssetTagsTest.php`
+
+**Interfaces:**
+- Consumes: the wired `reprise.tag_renderer` + `event_dispatcher` from the booted container.
+
+- [ ] **Step 1: Expose `event_dispatcher` in the functional kernel**
+
+In `tests/Kernel/FunctionalAppKernel.php`, inside `process()`, after the existing `setPublic(true)` lines, add:
+
+```php
+        if ($container->hasAlias('event_dispatcher')) {
+            $container->getAlias('event_dispatcher')->setPublic(true);
+        } elseif ($container->hasDefinition('event_dispatcher')) {
+            $container->getDefinition('event_dispatcher')->setPublic(true);
+        }
+```
+
+- [ ] **Step 2: Write the failing integration test**
+
+In `tests/Functional/DevAssetTagsTest.php`, add the import `use Symfony\Reprise\Event\RenderAssetTagEvent;` and the test:
+
+```php
+    public function testARenderAssetTagListenerCanNonceTheInjectedClientAndScripts()
+    {
+        $kernel = new FunctionalAppKernel(__DIR__.'/../fixtures/dev');
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        $container->get('event_dispatcher')->addListener(
+            RenderAssetTagEvent::class,
+            static function (RenderAssetTagEvent $event): void {
+                $event->attributes['nonce'] = 'test-nonce';
+            },
+        );
+
+        $html = $container->get('reprise.tag_renderer')->renderScriptTags('app');
+
+        $this->assertStringContainsString('src="http://127.0.0.1:5173/build/@vite/client" nonce="test-nonce">', $html);
+        $this->assertStringContainsString('src="http://127.0.0.1:5173/build/app.js" type="module" nonce="test-nonce">', $html);
+    }
+```
+
+- [ ] **Step 3: Run it**
+
+Run: `vendor/bin/phpunit tests/Functional/DevAssetTagsTest.php --filter testARenderAssetTagListenerCanNonceTheInjectedClientAndScripts`
+Expected: PASS — the same dispatcher instance is injected into `reprise.tag_renderer`, so the runtime listener's nonce lands on both the injected client and the entry script end-to-end. (If it fails because `event_dispatcher` is not fetchable, re-check Step 1 ran in the compiled container.)
+
+- [ ] **Step 4: Run the whole PHP suite**
+
+Run: `vendor/bin/phpunit`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/Kernel/FunctionalAppKernel.php tests/Functional/DevAssetTagsTest.php
+git commit -m "[TagRenderer] Cover RenderAssetTagEvent end to end"
+```
+
+---
+
+### Task 5: Docs, CHANGELOG, README
+
+**Files:**
+- Modify: `doc/index.rst` (new section after the per-call attributes paragraph, before `Features`)
+- Modify: `CHANGELOG.md` (new `## 0.7.0` at the top)
+- Modify: `README.md` (add one bullet to the feature list)
+
+**Interfaces:** none (documentation only).
+
+- [ ] **Step 1: Add the docs section**
+
+In `doc/index.rst`, immediately after the paragraph that ends `…while under Rsbuild the client is compiled into the bundle.` (the block ending around line 172) and before the `Features` heading, insert:
+
+```rst
+
+Customizing rendered tags (CSP nonce)
+-------------------------------------
+
+Every ``<script>`` and ``<link>`` Reprise renders — the entry files, the CSS, **and** the dev-server tags it injects
+itself (the Vite HMR client and, for React, the Fast Refresh preamble) — is passed through a ``RenderAssetTagEvent``
+just before it is written. Listen to it to add, change or remove attributes on every tag at once; the canonical use is
+a Content-Security-Policy ``nonce``:
+
+.. code-block:: php
+
+    namespace App\EventListener;
+
+    use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+    use Symfony\Reprise\Event\RenderAssetTagEvent;
+
+    #[AsEventListener]
+    final class CspNonceListener
+    {
+        public function __construct(private NonceGenerator $nonceGenerator)
+        {
+        }
+
+        public function __invoke(RenderAssetTagEvent $event): void
+        {
+            $event->attributes['nonce'] = $this->nonceGenerator->getNonce();
+        }
+    }
+
+``$event->attributes`` is a mutable map (assign to set, ``unset()`` to remove) and ``$event->isScript()`` /
+``$event->isLink()`` tell the two tag kinds apart. Because the injected HMR client and the React preamble go through
+the same event, a ``nonce`` added here also lands on them — which is exactly what a strict CSP needs, and the hook a
+NelmioSecurityBundle integration plugs into.
+```
+
+- [ ] **Step 2: Build the docs sanity-check (no RST errors)**
+
+Run: `git diff --check doc/index.rst`
+Expected: no whitespace errors. Visually confirm the heading underline length is at least as long as the title.
+
+- [ ] **Step 3: Add the CHANGELOG entry**
+
+In `CHANGELOG.md`, add a new section at the very top (above `## 0.6.0`):
+
+```markdown
+## 0.7.0
+
+- Add the `RenderAssetTagEvent`, dispatched before each rendered `<script>`/`<link>` (including the injected dev client and React preamble), so listeners can add, change or remove attributes such as a CSP nonce
+```
+
+- [ ] **Step 4: Add the README feature bullet**
+
+Open `README.md`, find the feature list, and add one bullet matching the existing style, e.g.:
+
+```markdown
+- Customizable tag attributes via a `RenderAssetTagEvent` (e.g. CSP nonce)
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add doc/index.rst CHANGELOG.md README.md
+git commit -m "[TagRenderer] Document the RenderAssetTagEvent"
+```
+
+---
+
+### Final: squash for the PR
+
+- [ ] **Squash the branch into one commit** (per the Symfony squash workflow — confirm the split with the maintainer first):
+
+```bash
+git reset --soft $(git merge-base main HEAD)
+git commit -m "[TagRenderer] Dispatch a RenderAssetTagEvent before rendering each tag"
+```
+
+(The design spec `docs/superpowers/specs/2026-08-06-render-asset-tag-event-design.md` is already committed on the branch and will fold into the squash.)
+
+- [ ] **Full green gate before pushing:**
+
+Run: `vendor/bin/phpunit && vendor/bin/phpstan analyse && vendor/bin/php-cs-fixer fix --dry-run --diff`
+Expected: tests pass, zero PHPStan errors, no style diff.
+
+## Self-Review
+
+**Spec coverage:**
+- Event class (private `type`, public `attributes`, `isScript`/`isLink`, no url, no getters) → Task 1. ✅
+- Unified attribute path (config + per-call seed client/preamble) → Task 3 (client/preamble build `+ $attributes + $this->scriptAttributes`). ✅
+- `tag()` helper routing files + client + preamble + css → Tasks 2 & 3. ✅
+- modulepreload excluded from the event → Task 2 (loop left untouched) + Task 3 `testModulepreloadLinksAreNotDispatchedToListeners`. ✅
+- DI wiring (`event_dispatcher`, nullable last arg) → Task 2 Steps 4/6. ✅
+- Tests: nonce on all tag kinds, isScript/isLink, attr removal, modulepreload-not-dispatched, no-dispatcher regression (existing suite), leak test inverted → Task 3; end-to-end wiring → Task 4. ✅
+- Docs single PHP example + NelmioSecurityBundle mention → Task 5 Step 1. ✅
+- CHANGELOG 0.7.0 + README → Task 5. ✅
+- event-dispatcher-contracts declared in `require` (interface); `event_dispatcher` service kept app-provided via `->nullOnInvalid()` + nullable guard; no `suggest` → Task 1 + Task 2 Step 6. ✅
+
+**Deviation from the spec (justified):** the spec put the end-to-end listener test in `DevAssetTagsTest` covering client + preamble + app. `FunctionalAppKernel` is `final` and takes no custom services, so Task 4 registers the listener on the booted container's `event_dispatcher` (made public) and asserts on the injected client + app script; the React preamble's nonce is proven in the Task 3 unit test (`testAListenerCanAddAnAttributeToEveryRenderedTag`), which uses the real `EventDispatcher`. Equivalent coverage.
+
+**Type consistency:** `RenderAssetTagEvent(type, attributes)`, `->attributes`, `->isScript()`/`->isLink()`, `tag(type, attributes, inlineBody)`, `reactRefreshPreamble(url)` are used identically across Tasks 1–4. `TYPE_SCRIPT`/`TYPE_LINK` are the only type literals. ✅
+
+**Placeholder scan:** every code step contains full code; test steps include assertions; no TBD/TODO. ✅

--- a/docs/superpowers/specs/2026-08-06-render-asset-tag-event-design.md
+++ b/docs/superpowers/specs/2026-08-06-render-asset-tag-event-design.md
@@ -1,0 +1,147 @@
+# RenderAssetTagEvent for RepriseBundle
+
+Date: 2026-08-06. Status: approved (design validated in brainstorm; spec pending user review). Target release: 0.7.0.
+
+## Context
+
+Issue [#71](https://github.com/symfony/reprise/issues/71) asks for a way to put a per-request `nonce` (CSP) on every rendered tag. Today `TagRenderer::renderScriptTags()` applies the configured `script_attributes` and the per-call `attributes` **only** to the app `<script>` tags. Three tags Reprise emits itself slip through:
+
+- the injected HMR dev client (`<script type="module" src="@vite/client">`) — hardcoded, no attributes;
+- the inline React Refresh preamble (`<script type="module">…</script>`) — no attributes;
+- (the `<link rel="modulepreload">` hints — but nonce does not apply to preloads, see below).
+
+Under a strict CSP (`script-src` with a nonce, no `unsafe-inline`), an inline script without a nonce is blocked outright, so the React preamble is exactly the case where a nonce matters most.
+
+This is a deferred item from the `2026-07-25-encore-parity-batch` spec, which already noted the HMR client / preamble / modulepreload tags "belong to the deferred `RenderAssetTagEvent` feature". WebpackEncoreBundle ships the same [`RenderAssetTagEvent`](https://github.com/symfony/webpack-encore-bundle/blob/2.x/src/Event/RenderAssetTagEvent.php); mirroring it also unblocks [nelmio/NelmioSecurityBundle#314](https://github.com/nelmio/NelmioSecurityBundle/issues/314) — one event, two use cases (the reported nonce need + a future automatic NelmioSecurityBundle integration listener).
+
+Encore never had this problem: webpack-dev-server injects its own client, so Encore's event fires only on real files. Reprise injects the client + preamble itself (backend integration), so to actually close #71 the event must also cover those.
+
+## Decisions (from brainstorm)
+
+1. **Event scope**: every tag Reprise emits goes through the event — app JS/CSS files, the injected HMR client, and the inline React preamble. The preamble has no `src` URL; rather than carry a nullable `url` (the inline case would make Encore's `getUrl()` return `?string`), the event carries **no dedicated url** at all — a listener that needs it derives it from `attributes['src']`/`['href']`.
+2. **Unified attribute path**: the configured `script_attributes`/`link_attributes` and the per-call `attributes` seed **all** script tags (files, client, preamble), then the event is dispatched. So `reprise_entry_script_tags('app', {nonce: csp_nonce('script')})` covers the client without a listener, and the event covers the global/automatic (Nelmio) case. Consequence to document: a global `script_attributes` such as `defer`/`async` now also lands on the injected client.
+3. **modulepreload excluded**: `<link rel="modulepreload">` tags are not routed through the event and do not receive `link_attributes`. They are an internal performance hint mirroring the HTTP `Link:` preload header, not a user asset tag, and CSP nonces do not apply to preloads.
+4. **Docs**: this is a backend, bundler-agnostic feature (no JS side), so it ships a single PHP listener example — not the usual Vite+Rsbuild pair, and no JS/functional bundler test symmetry.
+
+## The event class
+
+`src/Event/RenderAssetTagEvent.php` — **public API** (not `@internal`; it is the extension point). PHP 8.4 native shape, no getter/setter ceremony:
+
+```php
+namespace Symfony\Reprise\Event;
+
+/**
+ * Dispatched each time a <script> or <link> tag is rendered, so listeners can add, change
+ * or remove attributes (e.g. a CSP nonce) before the tag is written.
+ */
+final class RenderAssetTagEvent
+{
+    public const TYPE_SCRIPT = 'script';
+    public const TYPE_LINK = 'link';
+
+    /**
+     * @param array<string, bool|string> $attributes mutable; add/change/remove entries directly
+     */
+    public function __construct(
+        private readonly string $type,
+        public array $attributes,
+    ) {
+    }
+
+    public function isScript(): bool { return self::TYPE_SCRIPT === $this->type; }
+    public function isLink(): bool { return self::TYPE_LINK === $this->type; }
+}
+```
+
+Shape rationale:
+
+- **`attributes` is a public mutable array**, not getter/setter — a listener writes `$event->attributes['nonce'] = $nonce` / `unset(...)`. Property hooks are the wrong tool here: `type` is an immutable scalar (a plain `readonly` promoted prop, matching the rest of `src/`), and `attributes` is mutated *by key*, which a `set` hook does not intercept — so a hook would collapse to exactly this public array anyway.
+- **`type` stays private**, exposed through the semantic `isScript()`/`isLink()` methods (same encapsulation as Encore, just shorter names). The `TYPE_*` consts stay public so `TagRenderer` names them at the call site.
+- **No `url`**: it lives in `attributes` (`src`/`href`), so a listener reads `$event->attributes['src'] ?? $event->attributes['href'] ?? null`. Avoids the nullable-url wart the inline preamble would otherwise create.
+- No render veto/skip capability (Encore has none; #71 does not need it).
+
+Migration note: this diverges from Encore's method API (`getAttributes()`/`setAttribute()`). Adapting a migrated Encore listener is a one-line change; Reprise is pre-1.0 with no BC promise.
+
+## TagRenderer refactor
+
+Introduce one private helper every user-facing tag flows through:
+
+```php
+private function tag(string $type, array $attributes, ?string $inlineBody = null): string
+{
+    if (null !== $this->eventDispatcher) {
+        $event = $this->eventDispatcher->dispatch(new RenderAssetTagEvent($type, $attributes));
+        $attributes = $event->attributes;
+    }
+
+    if (RenderAssetTagEvent::TYPE_LINK === $type) {
+        return \sprintf('<link %s>', $this->attributes($attributes));
+    }
+
+    return \sprintf('<script %s>%s</script>', $this->attributes($attributes), $inlineBody ?? '');
+}
+```
+
+Call sites, all through `tag()`:
+
+- **Injected HMR client** (currently `TagRenderer.php:66`): build `['type' => 'module', 'src' => $client] + $attributes + $this->scriptAttributes`, then `tag(TYPE_SCRIPT, …)`. Now inherits config/per-call attributes + the event. No integrity (the dev URL is not in the integrity map).
+- **React preamble** (currently `:68`/`renderReactRefreshPreamble` at `:145`): `renderReactRefreshPreamble()` is reduced to return the **inner JS body only** (no `<script>` wrapper); the block builds `['type' => 'module'] + $attributes + $this->scriptAttributes` and calls `tag(TYPE_SCRIPT, $attrs, inlineBody: $body)`.
+- **App JS files** (`:81`): unchanged merge + `applyIntegrity()`, then `tag(TYPE_SCRIPT, $tagAttributes)` instead of the inline `sprintf`.
+- **CSS `<link rel="stylesheet">`** (`:103`): unchanged merge + `applyIntegrity()`, then `tag(TYPE_LINK, $tagAttributes)`.
+
+Unchanged: the `<link rel="modulepreload">` loop (`:73`) keeps its direct `attributes()` rendering (no event); `applyIntegrity()`/`integrityFor()`; the WebLink `preload()` `Link:` headers; the `injectedClients` dedup set; merge precedence (base `src`/`type`/`rel`/`href` > per-call > config, integrity applied last so a listener still sees it and, per Encore, may override it).
+
+## DI wiring
+
+`TagRenderer::__construct` gains a nullable last parameter:
+
+```php
+private readonly ?EventDispatcherInterface $eventDispatcher = null,   // Symfony\Contracts\EventDispatcher
+```
+
+Appended **last** so existing positional args do not shift. In `RepriseBundle::loadExtension`, add `service('event_dispatcher')->nullOnInvalid()` as the final argument of `reprise.tag_renderer`.
+
+**Dependency — declare `symfony/event-dispatcher-contracts` (`^3`) in `require`.** It provides the `EventDispatcherInterface` the constructor type-hints, and declaring it is honest: `symfony/event-dispatcher` is already used unconditionally by `ResetAssetsEventListener` (`EventSubscriberInterface`), so the contracts are effectively required already. Distinguish the *interface* from the *service*: the contracts package guarantees the **interface**; the concrete `event_dispatcher` **service** is registered by the app (framework-bundle), not by the contracts — so it is wired with `service('event_dispatcher')->nullOnInvalid()` and guarded by the nullable ctor arg + `if (null !== $this->eventDispatcher)` in `tag()`. **No `composer suggest` block** (not a Symfony practice). Nullable also keeps `TagRenderer` unit-testable without a dispatcher. (The bundle's broader missing runtime `require`s — http-kernel, config, dependency-injection, http-foundation, event-dispatcher, service-contracts — are a separate composer audit, out of scope here.)
+
+## Tests
+
+`tests/Asset/TagRendererTest.php` (PHP unit; backend-only, no bundler test pair):
+
+- a stub `EventDispatcherInterface` recording each event and mutating it (adds `nonce`);
+- the nonce lands on app `<script>` tags, the injected HMR client, the React preamble, and CSS `<link>` tags;
+- `isScript()`/`isLink()` return the right value per dispatched event; the preamble event carries no `src` in `attributes`;
+- a listener that `unset($event->attributes[...])` drops the attribute from the output;
+- `modulepreload` links are **not** dispatched and carry no listener attribute;
+- **no dispatcher → output byte-identical to today** (regression guard).
+
+Functional (`tests/Functional/DevAssetTagsTest.php`, dev fixtures already wired there): register a real listener in the functional kernel that sets `nonce="test"`; assert it appears on the injected `@vite/client` script, the React preamble, and the app scripts. A build-mode assertion (`AssetTagsTest`) confirms the nonce on file tags.
+
+## Docs
+
+`doc/index.rst`: a new section ("Customizing rendered tags / CSP nonce") after the Twig attributes section, with one PHP listener example:
+
+```php
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Reprise\Event\RenderAssetTagEvent;
+
+#[AsEventListener]
+final class CspNonceListener
+{
+    public function __construct(private NonceGenerator $nonceGenerator) {}
+
+    public function __invoke(RenderAssetTagEvent $event): void
+    {
+        $event->attributes['nonce'] = $this->nonceGenerator->getNonce();
+    }
+}
+```
+
+Note that it also covers the injected dev client and the React preamble, and mention that this is the hook a NelmioSecurityBundle integration uses. README feature list += the event.
+
+## CHANGELOG
+
+New `## 0.7.0` section, one bullet: add the `RenderAssetTagEvent`, dispatched before each rendered `<script>`/`<link>` (including the injected dev client and React preamble), letting listeners add/change/remove attributes such as a CSP nonce.
+
+## Commit / branch
+
+Branch `render-asset-tag-event` off `main`. Single feature commit, scope `[TagRenderer]`, squash-merged.

--- a/playground/src/EventListener/RenderAssetTagListener.php
+++ b/playground/src/EventListener/RenderAssetTagListener.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\EventListener;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Reprise\Event\RenderAssetTagEvent;
+
+/**
+ * Demonstrates RenderAssetTagEvent by stamping a marker attribute onto every rendered
+ * <script>/<link>, including the tags Reprise injects itself.
+ */
+#[AsEventListener]
+final class RenderAssetTagListener
+{
+    public function __invoke(RenderAssetTagEvent $event): void
+    {
+        $event->attributes['data-rendered-by'] = 'reprise';
+    }
+}

--- a/playground/tests/e2e/render-asset-tag-event.test.ts
+++ b/playground/tests/e2e/render-asset-tag-event.test.ts
@@ -1,0 +1,35 @@
+import { type Browser, chromium } from 'playwright'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { expectNoErrors, withPage } from './support'
+
+let browser: Browser
+
+beforeAll(async () => {
+  browser = await chromium.launch()
+})
+
+afterAll(async () => {
+  await browser?.close()
+})
+
+describe('RenderAssetTagEvent lets a listener stamp attributes on the rendered tags', () => {
+  test('every app <script>/<link> on the home page carries data-rendered-by="reprise"', async () => {
+    await withPage(browser, async ({ page, errors }) => {
+      await page.goto('/', { waitUntil: 'load' })
+
+      const stamped = await page.evaluate(() => {
+        const tags = document.querySelectorAll(
+          'head script[src*="/build/"], head link[rel="stylesheet"][href*="/build/"]',
+        )
+        return Array.from(tags, (el) => el.getAttribute('data-rendered-by'))
+      })
+
+      expect(stamped.length, 'app script/link tags found').toBeGreaterThan(0)
+      for (const value of stamped) {
+        expect(value, 'each tag carries data-rendered-by').toBe('reprise')
+      }
+
+      expectNoErrors(errors)
+    })
+  })
+})

--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -15,7 +15,9 @@ use Symfony\Component\Asset\Packages;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\WebLink\GenericLinkProvider;
 use Symfony\Component\WebLink\Link;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Service\ResetInterface;
+use Symfony\Reprise\Event\RenderAssetTagEvent;
 
 /**
  * Renders the <script>/<link> tags for an entry, resolving each entrypoints.json reference through
@@ -48,6 +50,7 @@ final class TagRenderer implements ResetInterface
         private readonly bool $preload = true,
         private readonly array $scriptAttributes = [],
         private readonly array $linkAttributes = [],
+        private readonly ?EventDispatcherInterface $eventDispatcher = null,
     ) {
     }
 
@@ -60,12 +63,15 @@ final class TagRenderer implements ResetInterface
         $lookup = $this->collection->getEntrypointsLookup($build);
         $integrity = $lookup->getIntegrityData();
         $tags = [];
+        $scriptDefaults = $attributes + $this->scriptAttributes;
 
         $devServer = $lookup->getDevServer();
         if (null !== $devServer && null !== $devServer->client && !isset($this->injectedClients[$devServer->client])) {
-            $tags[] = \sprintf('<script type="module" src="%s"></script>', htmlspecialchars($devServer->client, \ENT_QUOTES));
+            $clientAttributes = ['type' => 'module', 'src' => $devServer->client] + $scriptDefaults;
+            $tags[] = $this->tag(RenderAssetTagEvent::TYPE_SCRIPT, $clientAttributes);
             if (null !== $devServer->reactRefresh) {
-                $tags[] = $this->renderReactRefreshPreamble($devServer->reactRefresh);
+                $preambleAttributes = ['type' => 'module'] + $scriptDefaults;
+                $tags[] = $this->tag(RenderAssetTagEvent::TYPE_SCRIPT, $preambleAttributes, $this->reactRefreshPreamble($devServer->reactRefresh));
             }
             $this->injectedClients[$devServer->client] = true;
         }
@@ -80,9 +86,9 @@ final class TagRenderer implements ResetInterface
 
         foreach ($lookup->getJavaScriptFiles($entryName) as $reference) {
             $url = $this->url($reference, $packageName);
-            $tagAttributes = ['src' => $url, 'type' => 'module'] + $attributes + $this->scriptAttributes;
+            $tagAttributes = ['src' => $url, 'type' => 'module'] + $scriptDefaults;
             $this->applyIntegrity($tagAttributes, $reference, $integrity);
-            $tags[] = \sprintf('<script %s></script>', $this->attributes($tagAttributes));
+            $tags[] = $this->tag(RenderAssetTagEvent::TYPE_SCRIPT, $tagAttributes);
             // modulepreload, not `preload as=script`: the tag is a module, and a classic-script preload
             // mismatches its credentials/CORS mode so the browser discards it.
             $this->preload($url, 'modulepreload', null, $reference, $integrity);
@@ -104,7 +110,7 @@ final class TagRenderer implements ResetInterface
             $url = $this->url($reference, $packageName);
             $tagAttributes = ['rel' => 'stylesheet', 'href' => $url] + $attributes + $this->linkAttributes;
             $this->applyIntegrity($tagAttributes, $reference, $integrity);
-            $tags[] = \sprintf('<link %s>', $this->attributes($tagAttributes));
+            $tags[] = $this->tag(RenderAssetTagEvent::TYPE_LINK, $tagAttributes);
             $this->preload($url, 'preload', 'style', $reference, $integrity);
         }
 
@@ -138,22 +144,23 @@ final class TagRenderer implements ResetInterface
     }
 
     /**
-     * Emits Vite's React Fast Refresh preamble. `@vitejs/plugin-react` normally injects this into the
-     * HTML itself, but cannot when Symfony renders the page (backend integration), so we render it here
-     * before the entry. See https://vite.dev/guide/backend-integration.
+     * The inner body of Vite's React Fast Refresh preamble. `@vitejs/plugin-react` normally injects this
+     * into the HTML itself, but cannot when Symfony renders the page (backend integration), so we render
+     * it here before the entry, wrapped in a <script type="module"> by tag(). See
+     * https://vite.dev/guide/backend-integration.
      */
-    private function renderReactRefreshPreamble(string $reactRefreshUrl): string
+    private function reactRefreshPreamble(string $reactRefreshUrl): string
     {
         return \sprintf(
-            <<<'HTML'
-                <script type="module">
+            <<<'JS'
+
                 import RefreshRuntime from "%s";
                 RefreshRuntime.injectIntoGlobalHook(window);
                 window.$RefreshReg$ = () => {};
                 window.$RefreshSig$ = () => (type) => type;
                 window.__vite_plugin_react_preamble_installed__ = true;
-                </script>
-                HTML,
+
+                JS,
             htmlspecialchars($reactRefreshUrl, \ENT_QUOTES),
         );
     }
@@ -223,6 +230,22 @@ final class TagRenderer implements ResetInterface
         }
 
         return [$integrity[$reference], false === $this->crossorigin ? 'anonymous' : $this->crossorigin];
+    }
+
+    /**
+     * @param array<string, bool|string> $attributes
+     */
+    private function tag(string $type, array $attributes, ?string $inlineBody = null): string
+    {
+        if (null !== $this->eventDispatcher) {
+            $event = $this->eventDispatcher->dispatch(new RenderAssetTagEvent($type, $attributes));
+            $attributes = $event->attributes;
+        }
+
+        return match ($type) {
+            RenderAssetTagEvent::TYPE_LINK => \sprintf('<link %s>', $this->attributes($attributes)),
+            default => \sprintf('<script %s>%s</script>', $this->attributes($attributes), $inlineBody ?? ''),
+        };
     }
 
     /**

--- a/src/Event/RenderAssetTagEvent.php
+++ b/src/Event/RenderAssetTagEvent.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Reprise\Event;
+
+/**
+ * Dispatched each time a <script> or <link> tag is rendered, so listeners can add, change or
+ * remove attributes (e.g. a CSP nonce) before the tag is written. Covers the entry files, the
+ * CSS, and the dev-server tags Reprise injects itself (the HMR client and React preamble).
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class RenderAssetTagEvent
+{
+    public const TYPE_SCRIPT = 'script';
+    public const TYPE_LINK = 'link';
+
+    /**
+     * @param array<string, bool|string> $attributes mutable; add/change/remove entries directly
+     */
+    public function __construct(
+        private readonly string $type,
+        public array $attributes,
+    ) {
+    }
+
+    public function isScript(): bool
+    {
+        return self::TYPE_SCRIPT === $this->type;
+    }
+
+    public function isLink(): bool
+    {
+        return self::TYPE_LINK === $this->type;
+    }
+}

--- a/src/RepriseBundle.php
+++ b/src/RepriseBundle.php
@@ -155,6 +155,7 @@ final class RepriseBundle extends AbstractBundle
                 $config['preload'],
                 $config['script_attributes'],
                 $config['link_attributes'],
+                service('event_dispatcher')->nullOnInvalid(),
             ])
             ->tag('kernel.reset', ['method' => 'reset'])
         ;

--- a/tests/Asset/TagRendererTest.php
+++ b/tests/Asset/TagRendererTest.php
@@ -16,13 +16,16 @@ use Symfony\Component\Asset\Packages;
 use Symfony\Component\Asset\PathPackage;
 use Symfony\Component\Asset\UrlPackage;
 use Symfony\Component\Asset\VersionStrategy\EmptyVersionStrategy;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\WebLink\GenericLinkProvider;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Reprise\Asset\DevServer;
 use Symfony\Reprise\Asset\EntrypointsLookup;
 use Symfony\Reprise\Asset\EntrypointsLookupInterface;
 use Symfony\Reprise\Asset\TagRenderer;
+use Symfony\Reprise\Event\RenderAssetTagEvent;
 use Symfony\Reprise\Exception\UndefinedBuildException;
 use Symfony\Reprise\Tests\BuildCollectionTrait;
 
@@ -42,6 +45,7 @@ final class TagRendererTest extends TestCase
         ?RequestStack $requestStack = null,
         bool $preloadEnabled = true,
         ?Packages $packages = null,
+        ?EventDispatcherInterface $eventDispatcher = null,
     ): TagRenderer {
         $packages ??= new Packages(new PathPackage('/', new EmptyVersionStrategy()));
 
@@ -54,6 +58,7 @@ final class TagRendererTest extends TestCase
             $preloadEnabled,
             $scriptAttributes,
             $linkAttributes,
+            $eventDispatcher,
         );
     }
 
@@ -215,6 +220,19 @@ final class TagRendererTest extends TestCase
 
         $this->assertStringContainsString('import RefreshRuntime from "http://127.0.0.1:5173/build/@react-refresh"', $html);
         $this->assertStringContainsString('window.__vite_plugin_react_preamble_installed__ = true', $html);
+
+        $this->assertStringContainsString(
+            <<<'HTML'
+                <script type="module">
+                import RefreshRuntime from "http://127.0.0.1:5173/build/@react-refresh";
+                RefreshRuntime.injectIntoGlobalHook(window);
+                window.$RefreshReg$ = () => {};
+                window.$RefreshSig$ = () => (type) => type;
+                window.__vite_plugin_react_preamble_installed__ = true;
+                </script>
+                HTML,
+            $html,
+        );
 
         // Order matters: the HMR client, then the preamble, then the entry that imports the components.
         $clientPos = strpos($html, '@vite/client');
@@ -537,16 +555,85 @@ final class TagRendererTest extends TestCase
         );
     }
 
-    public function testPerCallAttributesDoNotLeakIntoTheHmrClient()
+    public function testPerCallAttributesApplyToTheHmrClient()
     {
+        // Unified path: per-call attributes now seed the injected client too (issue #71).
         $html = $this->renderer(
             js: ['http://127.0.0.1:5173/build/app.js'],
             devServer: new DevServer('http://127.0.0.1:5173', 'http://127.0.0.1:5173/build/@vite/client'),
         )->renderScriptTags('app', attributes: ['defer' => true]);
 
-        // The injected client tag is emitted verbatim; only the entry script carries the per-call attribute.
-        $this->assertStringContainsString('<script type="module" src="http://127.0.0.1:5173/build/@vite/client"></script>', $html);
+        $this->assertStringContainsString('<script type="module" src="http://127.0.0.1:5173/build/@vite/client" defer></script>', $html);
         $this->assertStringContainsString('src="http://127.0.0.1:5173/build/app.js" type="module" defer></script>', $html);
+    }
+
+    public function testAListenerCanAddAnAttributeToEveryRenderedTag()
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(RenderAssetTagEvent::class, static function (RenderAssetTagEvent $event): void {
+            $event->attributes['nonce'] = 'r4nd0m';
+        });
+
+        $renderer = $this->renderer(
+            js: ['http://127.0.0.1:5173/build/app.js'],
+            css: ['build/app.css'],
+            devServer: new DevServer(
+                'http://127.0.0.1:5173',
+                'http://127.0.0.1:5173/build/@vite/client',
+                'http://127.0.0.1:5173/build/@react-refresh',
+            ),
+            eventDispatcher: $dispatcher,
+        );
+
+        $scripts = $renderer->renderScriptTags('app');
+        $links = $renderer->renderLinkTags('app');
+
+        $this->assertStringContainsString('<script type="module" src="http://127.0.0.1:5173/build/@vite/client" nonce="r4nd0m"></script>', $scripts);
+        $this->assertStringContainsString('<script type="module" nonce="r4nd0m">', $scripts); // the preamble
+        $this->assertStringContainsString('src="http://127.0.0.1:5173/build/app.js" type="module" nonce="r4nd0m"></script>', $scripts);
+        $this->assertStringContainsString('<link rel="stylesheet" href="/build/app.css" nonce="r4nd0m">', $links);
+    }
+
+    public function testTheEventReportsScriptOrLinkToTheListener()
+    {
+        $types = [];
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(RenderAssetTagEvent::class, static function (RenderAssetTagEvent $event) use (&$types): void {
+            $types[] = $event->isScript() ? 'script' : ($event->isLink() ? 'link' : 'other');
+        });
+
+        $renderer = $this->renderer(js: ['build/app.js'], css: ['build/app.css'], eventDispatcher: $dispatcher);
+        $renderer->renderScriptTags('app');
+        $renderer->renderLinkTags('app');
+
+        $this->assertSame(['script', 'link'], $types);
+    }
+
+    public function testAListenerCanRemoveAConfiguredAttribute()
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(RenderAssetTagEvent::class, static function (RenderAssetTagEvent $event): void {
+            unset($event->attributes['defer']);
+        });
+
+        $html = $this->renderer(js: ['build/app.js'], scriptAttributes: ['defer' => true], eventDispatcher: $dispatcher)
+            ->renderScriptTags('app');
+
+        $this->assertSame('<script src="/build/app.js" type="module"></script>', $html);
+    }
+
+    public function testModulepreloadLinksAreNotDispatchedToListeners()
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(RenderAssetTagEvent::class, static function (RenderAssetTagEvent $event): void {
+            $event->attributes['nonce'] = 'r4nd0m';
+        });
+
+        $html = $this->renderer(js: ['build/app.js'], preload: ['build/shared.js'], eventDispatcher: $dispatcher)
+            ->renderScriptTags('app');
+
+        $this->assertStringContainsString('<link rel="modulepreload" href="/build/shared.js">', $html);
+        $this->assertStringContainsString('<script src="/build/app.js" type="module" nonce="r4nd0m"></script>', $html);
     }
 
     public function testPerCallAttributesCannotSpoofIntegrity()

--- a/tests/Functional/DevAssetTagsTest.php
+++ b/tests/Functional/DevAssetTagsTest.php
@@ -12,17 +12,24 @@
 namespace Symfony\Reprise\Tests\Functional;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Reprise\Asset\TagRenderer;
+use Symfony\Reprise\Event\RenderAssetTagEvent;
 use Symfony\Reprise\Tests\Kernel\FunctionalAppKernel;
 
 final class DevAssetTagsTest extends TestCase
 {
-    private function renderer(string $fixture): TagRenderer
+    private function container(string $fixture): ContainerInterface
     {
         $kernel = new FunctionalAppKernel(__DIR__.'/../fixtures/'.$fixture);
         $kernel->boot();
 
-        return $kernel->getContainer()->get('reprise.tag_renderer');
+        return $kernel->getContainer();
+    }
+
+    private function renderer(string $fixture): TagRenderer
+    {
+        return $this->container($fixture)->get('reprise.tag_renderer');
     }
 
     public function testViteDevInjectsTheHmrClientAndServesFromTheOrigin()
@@ -46,5 +53,22 @@ final class DevAssetTagsTest extends TestCase
             HTML;
 
         $this->assertSame($expected, $this->renderer('dev-rspack')->renderScriptTags('app'));
+    }
+
+    public function testARenderAssetTagListenerCanNonceTheInjectedClientAndScripts()
+    {
+        $container = $this->container('dev');
+
+        $container->get('event_dispatcher')->addListener(
+            RenderAssetTagEvent::class,
+            static function (RenderAssetTagEvent $event): void {
+                $event->attributes['nonce'] = 'test-nonce';
+            },
+        );
+
+        $html = $container->get('reprise.tag_renderer')->renderScriptTags('app');
+
+        $this->assertStringContainsString('src="http://127.0.0.1:5173/build/@vite/client" nonce="test-nonce">', $html);
+        $this->assertStringContainsString('src="http://127.0.0.1:5173/build/app.js" type="module" nonce="test-nonce">', $html);
     }
 }

--- a/tests/Kernel/FunctionalAppKernel.php
+++ b/tests/Kernel/FunctionalAppKernel.php
@@ -83,5 +83,11 @@ final class FunctionalAppKernel extends Kernel implements CompilerPassInterface
         if ($container->hasDefinition('assets.packages')) {
             $container->getDefinition('assets.packages')->setPublic(true);
         }
+
+        if ($container->hasAlias('event_dispatcher')) {
+            $container->getAlias('event_dispatcher')->setPublic(true);
+        } elseif ($container->hasDefinition('event_dispatcher')) {
+            $container->getDefinition('event_dispatcher')->setPublic(true);
+        }
     }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update CHANGELOG.md file -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and CHANGELOG.md files -->
| Documentation? | yes <!-- required for new features, or documentation updates -->
| Issues         | Fix #71 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
