### PR TITLE
[Composer][Cache] Fix declared dependencies and cache activation detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,3 +274,5 @@ jobs:
               run: vendor/bin/phpstan analyse
             - name: PHP-CS-Fixer
               run: vendor/bin/php-cs-fixer fix --dry-run --diff
+            - name: Analyse Composer dependencies
+              run: vendor/bin/composer-dependency-analyser

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
+
+return new Configuration()
+    // Symfony's DI configurator helpers are plain functions the analyser cannot resolve statically.
+    ->ignoreUnknownFunctions([
+        'Symfony\Component\DependencyInjection\Loader\Configurator\service',
+        'Symfony\Component\DependencyInjection\Loader\Configurator\service_locator',
+    ])
+    // Interface-only packages pulled in transitively by components we require (psr/cache by symfony/cache,
+    // event-dispatcher-contracts by symfony/event-dispatcher).
+    ->ignoreErrorsOnPackage('psr/cache', [ErrorType::SHADOW_DEPENDENCY])
+    ->ignoreErrorsOnPackage('symfony/event-dispatcher-contracts', [ErrorType::SHADOW_DEPENDENCY])
+    // Optional dependencies used behind class_exists() guards, so kept in require-dev.
+    ->ignoreErrorsOnPackage('symfony/cache', [ErrorType::DEV_DEPENDENCY_IN_PROD])
+    ->ignoreErrorsOnPackage('symfony/web-link', [ErrorType::DEV_DEPENDENCY_IN_PROD]);

--- a/composer.json
+++ b/composer.json
@@ -17,17 +17,23 @@
     "require": {
         "php": ">=8.4",
         "symfony/asset": "^7.4|^8.0",
-        "symfony/event-dispatcher-contracts": "^3",
+        "symfony/config": "^7.4|^8.0",
+        "symfony/dependency-injection": "^7.4|^8.0",
+        "symfony/event-dispatcher": "^7.4|^8.0",
+        "symfony/http-foundation": "^7.4|^8.0",
+        "symfony/http-kernel": "^7.4|^8.0",
+        "symfony/service-contracts": "^3",
         "twig/twig": "^3.0"
     },
     "require-dev": {
         "symfony/framework-bundle": "^7.4|^8.0",
+        "symfony/error-handler": "^7.4|^8.0",
+        "symfony/cache": "^7.4|^8.0",
+        "symfony/web-link": "^7.4|^8.0",
         "phpunit/phpunit": "^13.2",
         "phpstan/phpstan": "^2.2",
         "friendsofphp/php-cs-fixer": "^3.95",
-        "symfony/web-link": "^7.4|^8.0",
-        "symfony/cache": "^7.4|^8.0",
-        "symfony/var-exporter": "^7.4|^8.0"
+        "shipmonk/composer-dependency-analyser": "^1.8"
     },
     "autoload": {
         "psr-4": { "Symfony\\Reprise\\": "src/" }

--- a/src/RepriseBundle.php
+++ b/src/RepriseBundle.php
@@ -11,11 +11,11 @@
 
 namespace Symfony\Reprise;
 
+use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
-use Symfony\Component\VarExporter\VarExporter;
 use Symfony\Reprise\Asset\EntrypointsLookup;
 use Symfony\Reprise\Asset\EntrypointsLookupCollection;
 use Symfony\Reprise\Asset\EntrypointsLookupCollectionInterface;
@@ -91,7 +91,7 @@ final class RepriseBundle extends AbstractBundle
     {
         $services = $container->services();
 
-        if ($config['cache'] && !class_exists(VarExporter::class)) {
+        if ($config['cache'] && !class_exists(PhpArrayAdapter::class)) {
             throw new \LogicException('Enabling "reprise.cache" requires the Symfony Cache component. Run "composer require symfony/cache".');
         }
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

Adds [shipmonk/composer-dependency-analyser](https://github.com/shipmonk-rnd/composer-dependency-analyser) to the `php-qa` CI job. Every push now verifies that `composer.json` declares exactly the packages the code actually uses. Enabling it surfaced real drift, fixed in this PR:

- **Promoted to `require`**: `symfony/config`, `symfony/dependency-injection`, `symfony/event-dispatcher`, `symfony/http-foundation`, `symfony/http-kernel`, `symfony/service-contracts` — all used directly in `src/` but only available transitively before.
- **Fixed a latent cache-guard bug**: `RepriseBundle` gated the opt-in entrypoints cache on `class_exists(VarExporter::class)`, but `symfony/var-exporter` is a hard dependency of `symfony/dependency-injection`, so that check was always true. The guard now checks `PhpArrayAdapter` (the class actually instantiated), which matches the error message and correctly requires `symfony/cache` to be installed.
- **`require-dev` cleanup**: `symfony/cache` and `symfony/web-link` stay in `require-dev` (optional features behind `class_exists()` guards); `symfony/var-exporter` removed (arrives transitively via `symfony/cache`); `symfony/error-handler` added (test bootstrap only).
- A `composer-dependency-analyser.php` config records intentional exceptions (transitive interface packages, DI helper functions, and the two optional `class_exists()`-guarded dependencies) with inline reasons.
