### PR TITLE
[Manifest] Strip url() query and fragment from Rspack keys

### DIFF
--- a/assets/src/collectors/rspack.ts
+++ b/assets/src/collectors/rspack.ts
@@ -8,8 +8,13 @@ export interface RspackStats {
     assets?: { name: string; info?: { sourceFilename?: string } }[];
 }
 
+// Rspack keeps the `url()` query/fragment (`./x.woff2?v=1`) in `sourceFilename`, Vite doesn't.
+function stripUrlSuffix(name: string): string {
+    return name.replace(/[?#].*$/, '');
+}
+
 function fileExt(name: string): string {
-    return extname(name.split('?')[0]).slice(1);
+    return extname(stripUrlSuffix(name)).slice(1);
 }
 
 function isHotUpdate(name: string): boolean {
@@ -38,7 +43,8 @@ export function statsToGraph(stats: RspackStats): NormalizedGraph {
     }
     for (const asset of stats.assets ?? []) {
         const logical = asset.info?.sourceFilename;
-        if (logical && !isHotUpdate(asset.name)) assets.push({ logicalName: logical, fileName: asset.name });
+        if (!logical || isHotUpdate(asset.name)) continue;
+        assets.push({ logicalName: stripUrlSuffix(logical), fileName: asset.name });
     }
 
     return { entryPoints, assets };

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -195,6 +195,7 @@ export interface DevServer {
 }
 
 export interface AssetEntry {
+    /** Manifest key before `manifestKeyPrefix`: source path relative to the project root, forward slashes, no query or fragment. */
     logicalName: string;
     fileName: string;
 }

--- a/assets/test/collectors/rspack.test.ts
+++ b/assets/test/collectors/rspack.test.ts
@@ -36,12 +36,26 @@ describe('statsToGraph', () => {
         expect(graph.assets).toContainEqual({ logicalName: 'images/logo.svg', fileName: 'logo.e5.svg' });
     });
 
+    it('strips a url() query or fragment from the manifest key', () => {
+        const graph = statsToGraph({
+            assets: [
+                { name: 'font.e5.woff2', info: { sourceFilename: 'fonts/font.woff2?v=1' } },
+                { name: 'icon.f6.svg', info: { sourceFilename: 'images/icon.svg#frag' } },
+            ],
+        });
+        expect(graph.assets).toContainEqual({ logicalName: 'fonts/font.woff2', fileName: 'font.e5.woff2' });
+        expect(graph.assets).toContainEqual({ logicalName: 'images/icon.svg', fileName: 'icon.f6.svg' });
+    });
+
     it('tolerates empty/absent stats sections', () => {
         expect(statsToGraph({})).toEqual({ entryPoints: {}, assets: [] });
     });
 
-    it('strips a query string before reading the extension', () => {
-        const graph = statsToGraph({ entrypoints: { app: { assets: [{ name: 'app.a1.js?v=1.2.3' }] } } });
+    it('strips a query string or fragment before reading the extension', () => {
+        const graph = statsToGraph({
+            entrypoints: { app: { assets: [{ name: 'app.a1.js?v=1.2.3' }, { name: 'app.b2.css#frag' }] } },
+        });
         expect(graph.entryPoints.app.js).toEqual(['app.a1.js?v=1.2.3']);
+        expect(graph.entryPoints.app.css).toEqual(['app.b2.css#frag']);
     });
 });

--- a/assets/test/fixtures/css-url-query/app.js
+++ b/assets/test/fixtures/css-url-query/app.js
@@ -1,0 +1,1 @@
+import './style.css';

--- a/assets/test/fixtures/css-url-query/fonts/plain.woff2
+++ b/assets/test/fixtures/css-url-query/fonts/plain.woff2
@@ -1,0 +1,1 @@
+wOF2pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp

--- a/assets/test/fixtures/css-url-query/fonts/query.woff2
+++ b/assets/test/fixtures/css-url-query/fonts/query.woff2
@@ -1,0 +1,1 @@
+wOF2qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq

--- a/assets/test/fixtures/css-url-query/media/icon.svg
+++ b/assets/test/fixtures/css-url-query/media/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4"><rect id="frag" width="4" height="4"/></svg>

--- a/assets/test/fixtures/css-url-query/style.css
+++ b/assets/test/fixtures/css-url-query/style.css
@@ -1,0 +1,12 @@
+@font-face {
+    font-family: "Query";
+    src: url("./fonts/query.woff2?v=1") format("woff2");
+}
+@font-face {
+    font-family: "Plain";
+    src: url("./fonts/plain.woff2") format("woff2");
+}
+.a {
+    font-family: "Query", "Plain";
+    background: url("./media/icon.svg#frag");
+}

--- a/assets/test/integration/css-url-query-keys.test.ts
+++ b/assets/test/integration/css-url-query-keys.test.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRsbuild } from '@rsbuild/core';
+import { build } from 'vite';
+import { describe, expect, it } from 'vitest';
+import SymfonyRsbuild from '../../src/rsbuild';
+import SymfonyVite from '../../src/vite';
+
+// `@font-face { src: url('./x.woff2?v=1') }` and `url('./icon.svg#frag')` are everyday CSS. The
+// query/fragment addresses the *reference*, not the file, so both bundlers must key the emitted asset
+// under the bare source path — otherwise `asset('fonts/query.woff2')` misses in Twig on one bundler only.
+const fixture = join(import.meta.dirname, '../fixtures/css-url-query');
+
+describe('css url() query and fragment are stripped from manifest keys (Vite/Rsbuild parity)', () => {
+    it('vite keys the asset without the query or fragment', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-urlq-vite-'));
+        await build({
+            root: fixture,
+            logLevel: 'silent',
+            build: {
+                emptyOutDir: true,
+                assetsInlineLimit: 0,
+                rollupOptions: { input: { app: join(fixture, 'app.js') } },
+            },
+            plugins: [SymfonyVite({ outputPath: out, publicPath: '/build/' })],
+        });
+
+        const manifest = JSON.parse(readFileSync(join(out, 'manifest.json'), 'utf8'));
+        expect(manifest['build/fonts/query.woff2']).toMatch(/^\/build\/.*\.woff2$/);
+        expect(manifest['build/fonts/plain.woff2']).toMatch(/^\/build\/.*\.woff2$/);
+        expect(manifest['build/media/icon.svg']).toMatch(/^\/build\/.*\.svg$/);
+        expect(Object.keys(manifest).filter((k) => k.includes('?') || k.includes('#'))).toEqual([]);
+    }, 30_000);
+
+    it('rsbuild keys the asset without the query or fragment', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-urlq-rsbuild-'));
+        const rsbuild = await createRsbuild({
+            cwd: fixture,
+            rsbuildConfig: {
+                mode: 'production',
+                source: { entry: { app: join(fixture, 'app.js') } },
+                output: { dataUriLimit: 0 },
+                plugins: [SymfonyRsbuild({ outputPath: out, publicPath: '/build/' })],
+            },
+        });
+        await rsbuild.build();
+
+        const manifest = JSON.parse(readFileSync(join(out, 'manifest.json'), 'utf8'));
+        expect(manifest['build/fonts/query.woff2']).toMatch(/^\/build\/.*\.woff2$/);
+        expect(manifest['build/fonts/plain.woff2']).toMatch(/^\/build\/.*\.woff2$/);
+        expect(manifest['build/media/icon.svg']).toMatch(/^\/build\/.*\.svg$/);
+        expect(Object.keys(manifest).filter((k) => k.includes('?') || k.includes('#'))).toEqual([]);
+    }, 60_000);
+});


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update CHANGELOG.md file -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and CHANGELOG.md files -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
