### PR TITLE
[Docs] Add the backward compatibility promise and drop the experimental notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@
   📣 <a href="https://symfony.com/blog/introducing-symfony-reprise-the-symfony-integration-layer-for-modern-bundlers">Read the announcement blog post</a>
 </p>
 
-> [!WARNING]
-> **Experimental** this bundle is experimental and is likely to change, or even change drastically.
-
 Symfony Reprise covers only the Symfony-side glue the bundlers leave out:
 
 - 🎯 **Multiple entries**: build several independent entry points from one config

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,11 +1,6 @@
 Symfony Reprise
 ===============
 
-.. warning::
-
-    This bundle is experimental and is likely to change, or even change
-    drastically.
-
 Webpack Encore gave Symfony first-class asset integration for Webpack. Symfony Reprise brings the same to `Vite`_
 and `Rsbuild`_.
 
@@ -758,6 +753,12 @@ A few Encore features have no direct replacement:
 - The remaining ``configure*Plugin()`` calls (``configureManifestPlugin()``, ``configureMiniCssExtractPlugin()``,
   ``configureCssMinimizerPlugin()``, ``configureJsMinimizerPlugin()``, ``configureFriendlyErrorsPlugin()``): tuned
   Webpack internals that Reprise and the bundlers now own; nothing to port.
+
+Backward Compatibility promise
+------------------------------
+
+This bundle aims at following the same Backward Compatibility promise as the Symfony framework:
+https://symfony.com/doc/current/contributing/code/bc.html
 
 .. _Vite: https://vite.dev/
 .. _Rsbuild: https://rsbuild.dev/


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update CHANGELOG.md file -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and CHANGELOG.md files -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Follow the same backward compatibility promise as the Symfony framework, and remove the "experimental, likely to change drastically" notice from the README and docs now that the surface is stable for 1.0.
