### PR TITLE
[Vite] Support the top-level `input` option in dev mode, added in Vite 8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 1.1.0
+
+- Add support for the top-level `input` option in dev mode, added in Vite 8.2
+
+## 1.0.0
+
+Stable release! 🎉
+
 ## 0.8.0
 
 - Add a per-entry `hash` option to `copy` (default `true`): with `hash: false` the file is emitted at its logical path instead of a content-hashed one, and the hash moves to the `manifest.json` value as a `?<contenthash>` query string

--- a/assets/src/collectors/vite.ts
+++ b/assets/src/collectors/vite.ts
@@ -90,6 +90,7 @@ const CSS_EXTS = new Set(['.css', '.scss', '.sass', '.less', '.styl', '.stylus',
 
 export interface DevConfig {
     root: string;
+    input?: Rollup.InputOption;
     build: {
         rolldownOptions?: { input?: Rollup.InputOption };
         rollupOptions?: { input?: Rollup.InputOption };
@@ -98,9 +99,9 @@ export interface DevConfig {
 
 export function configToDevGraph(config: DevConfig): NormalizedGraph {
     const entryPoints: Record<string, EntryFiles> = {};
-    // rolldown-vite renamed `build.rollupOptions` to `build.rolldownOptions`; prefer the new key and
-    // fall back to the deprecated one so both current Vite and rolldown-vite keep working.
-    const input = config.build.rolldownOptions?.input ?? config.build.rollupOptions?.input;
+    // Three entry keys: rolldown-vite's `rolldownOptions`, Vite 7's `rollupOptions`, Vite 8's top-level
+    // `input`. Nested first because `vite build` resolves it first, so dev names the entries the build does.
+    const input = config.build.rolldownOptions?.input ?? config.build.rollupOptions?.input ?? config.input;
     const entries: Record<string, string> =
         typeof input === 'object' && input !== null && !Array.isArray(input) ? (input as Record<string, string>) : {};
 

--- a/assets/test/collectors/vite.test.ts
+++ b/assets/test/collectors/vite.test.ts
@@ -253,6 +253,26 @@ describe('configToDevGraph', () => {
         expect(graph.entryPoints.app).toEqual({ js: ['assets/app.js'], css: [], preload: [], dynamic: [] });
     });
 
+    it('reads the top-level input when nested build input is absent', () => {
+        const graph = configToDevGraph({
+            root: '/app',
+            input: { app: '/app/assets/app.js' },
+            build: {},
+        });
+        expect(graph.entryPoints.app).toEqual({ js: ['assets/app.js'], css: [], preload: [], dynamic: [] });
+    });
+
+    it('prefers nested build input over the top-level input', () => {
+        const graph = configToDevGraph({
+            root: '/app',
+            input: { topLevel: '/app/assets/top-level.js' },
+            build: { rolldownOptions: { input: { app: '/app/assets/app.js' } } },
+        });
+        expect(graph.entryPoints).toEqual({
+            app: { js: ['assets/app.js'], css: [], preload: [], dynamic: [] },
+        });
+    });
+
     it('prefers rolldownOptions.input over the deprecated rollupOptions', () => {
         const graph = configToDevGraph({
             root: '/app',

--- a/assets/test/integration/vite-build.test.ts
+++ b/assets/test/integration/vite-build.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { build } from 'vite';
 import { describe, expect, it } from 'vitest';
 import Symfony from '../../src/vite';
+import { hasTopLevelInput } from '../vite-version';
 
 const fixture = join(import.meta.dirname, '../fixtures/basic');
 
@@ -69,4 +70,28 @@ describe('vite build emits Symfony files', () => {
         expect(css).toContain('/build/');
         expect(css).not.toMatch(/url\(\/logo/); // must NOT reference /logo… at the root
     }, 30_000);
+});
+
+describe('vite top-level input', () => {
+    it.skipIf(!hasTopLevelInput)(
+        'emits Symfony files from the top-level input',
+        async () => {
+            const out = mkdtempSync(join(tmpdir(), 'ups-top-level-input-'));
+            await build({
+                root: fixture,
+                logLevel: 'silent',
+                input: { app: join(fixture, 'app.js'), admin: join(fixture, 'admin.js') },
+                build: { emptyOutDir: true },
+                plugins: [Symfony({ outputPath: out, publicPath: '/build/' })],
+            });
+
+            const entry = JSON.parse(readFileSync(join(out, 'entrypoints.json'), 'utf8'));
+            expect(Object.keys(entry.entryPoints).sort()).toEqual(['admin', 'app']);
+            expect(entry.entryPoints.app.js[0]).toMatch(/^build\/app-.*\.js$/);
+
+            const manifest = JSON.parse(readFileSync(join(out, 'manifest.json'), 'utf8'));
+            expect(manifest['build/app.js']).toMatch(/^\/build\/app-.*\.js$/);
+        },
+        30_000
+    );
 });

--- a/assets/test/integration/vite-dev.test.ts
+++ b/assets/test/integration/vite-dev.test.ts
@@ -5,6 +5,7 @@ import react from '@vitejs/plugin-react';
 import { createServer } from 'vite';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import Symfony from '../../src/vite';
+import { hasTopLevelInput } from '../vite-version';
 
 const fixture = join(import.meta.dirname, '../fixtures/basic');
 
@@ -60,6 +61,26 @@ describe('vite serve writes a dev entrypoints.json', () => {
             expect(entry.devServer.reactRefresh).toBe(`${entry.devServer.origin}/build/@react-refresh`);
         } finally {
             await reactServer.close();
+        }
+    });
+});
+
+describe('vite top-level input', () => {
+    it.skipIf(!hasTopLevelInput)('writes dev entries from the top-level input', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-dev-top-level-input-'));
+        const server = await createServer({
+            root: fixture,
+            logLevel: 'silent',
+            input: { app: join(fixture, 'app.js'), admin: join(fixture, 'admin.js') },
+            server: { port: 0, host: '127.0.0.1' },
+            plugins: [Symfony({ outputPath: out, publicPath: '/build/' })],
+        });
+        await server.listen();
+        try {
+            const entry = JSON.parse(readFileSync(join(out, 'entrypoints.json'), 'utf8'));
+            expect(Object.keys(entry.entryPoints).sort()).toEqual(['admin', 'app']);
+        } finally {
+            await server.close();
         }
     });
 });

--- a/assets/test/vite-version.ts
+++ b/assets/test/vite-version.ts
@@ -1,0 +1,6 @@
+import { version } from 'vite';
+
+const [major, minor] = version.split('.').map(Number);
+
+// The top-level `input` option landed in Vite 8.2; 8.1 and older only have `build.rollupOptions.input`.
+export const hasTopLevelInput = major > 8 || (major === 8 && minor >= 2);

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -56,13 +56,8 @@ Vite
     import Symfony from '@symfony/reprise/vite'
 
     export default defineConfig({
-      build: {
-        // On Vite 7 or older, use `rollupOptions` instead
-        rolldownOptions: {
-          input: {
-            app: './assets/app.js',
-          },
-        },
+      input: {
+        app: './assets/app.js',
       },
       plugins: [
         Symfony({
@@ -70,6 +65,8 @@ Vite
         }),
       ],
     })
+
+On Vite 8.1 and older, configure the entries with ``build.rollupOptions.input`` instead.
 
 Rsbuild
 ~~~~~~~
@@ -515,12 +512,8 @@ Give the widget its own config, pointing the plugin at a separate output directo
     import Symfony from '@symfony/reprise/vite'
 
     export default defineConfig({
-      build: {
-        rolldownOptions: {
-          input: {
-            widget: './assets/widget.js',
-          },
-        },
+      input: {
+        widget: './assets/widget.js',
       },
       plugins: [
         Symfony({
@@ -691,18 +684,18 @@ Your build config
 Most of ``webpack.config.js`` has no equivalent, because the bundler already does the work. The Symfony glue Encore
 layered on top of Webpack stays, as a Reprise plugin option:
 
-=========================================  ===========================================================================================
+=========================================  ============================================================================================
 Webpack Encore                             Reprise
-=========================================  ===========================================================================================
+=========================================  ============================================================================================
 ``setOutputPath()`` / ``setPublicPath()``  plugin ``outputPath`` / ``publicPath`` (the defaults fit a standard project)
 ``setManifestKeyPrefix()``                 plugin ``manifestKeyPrefix`` (see `Using a CDN`_)
-``addEntry()`` / ``addEntries()``          the bundler's own entry input: Vite ``build.rollupOptions.input``, Rsbuild ``source.entry``
+``addEntry()`` / ``addEntries()``          Vite ``input`` (Vite 8.1 and older: ``build.rollupOptions.input``); Rsbuild ``source.entry``
 ``enableVersioning()``                     nothing to do, content hashing is on by default
 ``enableIntegrityHashes()``                plugin ``integrity: { enabled: true }`` (see `Subresource Integrity`_)
 ``copyFiles()``                            plugin ``copy: [ ... ]`` (see `File copy`_)
 ``enableStimulusBridge()``                 plugin ``stimulus: 'assets/controllers.json'`` (see `Symfony UX / Stimulus controllers`_)
 ``configureDevServerOptions()``            nothing to do: run ``vite`` or ``rsbuild dev`` and Reprise points Twig at it
-=========================================  ===========================================================================================
+=========================================  ============================================================================================
 
 Everything Vite and Rsbuild handle themselves, you drop:
 

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -1,6 +1,6 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { defineConfig } from 'vite'
+import { defineConfig, version as viteVersion } from 'vite'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import vue from '@vitejs/plugin-vue'
@@ -11,15 +11,19 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const publicPath = process.env.CDN_BASE ?? '/build/'
 
+const input = {
+  app: resolve(__dirname, './assets/app.ts'),
+  admin: resolve(__dirname, './assets/admin.ts'),
+}
+
+// The top-level `input` option landed in Vite 8.2; the E2E matrix still runs Vite 7.
+const [viteMajor, viteMinor] = viteVersion.split('.').map(Number)
+const entry = viteMajor > 8 || (viteMajor === 8 && viteMinor >= 2)
+  ? { input }
+  : { build: { rollupOptions: { input } } }
+
 export default defineConfig({
-  build: {
-    rollupOptions: {
-      input: {
-        app: resolve(__dirname, './assets/app.ts'),
-        admin: resolve(__dirname, './assets/admin.ts'),
-      },
-    },
-  },
+  ...entry,
   plugins: [
     tailwindcss(),
     Inspect(),


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | -
| License        | MIT

Vite 8 introduced the root-level `input` option, but Reprise dev-manifest collection only read `build.rolldownOptions.input` and the Vite 7-compatible `build.rollupOptions.input`. Projects using the modern option therefore built correctly while their dev `entrypoints.json` contained no entries, leaving HMR with nothing to load.

This change makes the dev collector fall back to the resolved root-level input after the nested build inputs, matching Vite precedence and retaining Vite 7 compatibility. It also updates the Vite documentation and adds collector plus real dev-server coverage.

Tests:

* `pnpm build`
* `pnpm typecheck`
* `pnpm lint`
* `pnpm fmt:check`
* `pnpm test` (157 tests)