### PR TITLE
[Stimulus] Detect the lazy marker anywhere in a controller file

### DIFF
--- a/assets/src/core/stimulus.ts
+++ b/assets/src/core/stimulus.ts
@@ -39,14 +39,10 @@ interface ResolvedController {
     autoimports: string[];
 }
 
-// A controller opts into lazy loading with a `stimulusFetch: 'lazy'` comment directly above the
-// class (line/block comment, either quotes, `/*!...*/` survives minification) — recognised only
-// when the class is the very next code, so a stray marker elsewhere doesn't count:
-//
-//   /* stimulusFetch: 'lazy' */
-//   export default class extends Controller {}
-const LAZY_COMMENT_RE =
-    /(?:\/\*!?\s*stimulusFetch:\s*['"]lazy['"]\s*\*\/|\/\/\s*stimulusFetch:\s*['"]lazy['"])\s*(?:export\s+(?:default\s+)?)?(?:abstract\s+)?class\b/i;
+// A controller opts into lazy loading with a `stimulusFetch: 'lazy'` comment anywhere in the file
+// (line/block comment, either quotes, `/*!...*/` survives minification), like @symfony/stimulus-bridge.
+// The marker is not tied to a class: a dummy controller exporting a plain value opts in the same way.
+const LAZY_COMMENT_RE = /\/\*!?\s*stimulusFetch:\s*['"]lazy['"]\s*\*\/|\/\/\s*stimulusFetch:\s*['"]lazy['"]/i;
 const LOCAL_CONTROLLER_RE = /[-_]controller\.[jt]s$/;
 
 // Every other failure in this module reports a `@symfony/reprise:` error; a missing or malformed

--- a/assets/test/core/stimulus.test.ts
+++ b/assets/test/core/stimulus.test.ts
@@ -86,12 +86,16 @@ describe('generateControllersModule — local', () => {
         expect(src).toContain(posix(join(root, 'controllers/preserved_comment_controller.js')));
     });
 
-    it('ignores a lazy marker that sits above the imports (it must be directly above the class)', () => {
+    it('detects the lazy marker wherever it sits in the file, not only above the class', () => {
         const src = generateControllersModule(localOpts, root, false);
-        // The marker in `above_imports_controller.js` precedes the imports, not the class,
-        // so the controller stays eager rather than becoming a lazy dynamic import.
-        expect(src).toMatch(/"above-imports": controller_\d+/);
-        expect(src).not.toContain(`"above-imports": () => import(`);
+        expect(src).toContain(`"above-imports": () => import(`);
+        expect(src).toContain(posix(join(root, 'controllers/above_imports_controller.js')));
+    });
+
+    it('detects the lazy marker on a dummy controller that exports something other than a class', () => {
+        const src = generateControllersModule(localOpts, root, false);
+        expect(src).toContain(`"dummy": () => import(`);
+        expect(src).toContain(posix(join(root, 'controllers/dummy_controller.js')));
     });
 
     it('maps nested controllers with a double-dash identifier', () => {
@@ -115,11 +119,12 @@ describe('generateControllersModule — local', () => {
         expect(identifiers).toEqual([
             // eagerControllers: third-party first, then local controllers sorted by filename
             'acme--ux-hello--hello',
-            'above-imports',
             'admin--user',
             'greet',
             // lazyControllers: third-party first, then local controllers sorted by filename
             'acme--ux-map--map',
+            'above-imports',
+            'dummy',
             'heavy',
             'preserved-comment',
             'single-line',

--- a/assets/test/fixtures/stimulus/controllers/dummy_controller.js
+++ b/assets/test/fixtures/stimulus/controllers/dummy_controller.js
@@ -1,0 +1,2 @@
+/* stimulusFetch: 'lazy' */
+export default 'dummy-controller'

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -229,8 +229,8 @@ Then start the app from your entry:
 
 **Local controllers.** Any ``assets/controllers/*_controller.{js,ts}`` is registered automatically. The filename
 becomes the identifier (``hello_controller.js`` becomes ``hello``, ``admin/user_controller.js`` becomes
-``admin--user``). To load a controller on demand, put a ``stimulusFetch: 'lazy'`` comment directly above the
-class; a block or a single-line comment both work.
+``admin--user``). To load a controller on demand, put a ``stimulusFetch: 'lazy'`` comment anywhere in the file; a
+block or a single-line comment both work, even on dummy controllers that export a plain value instead of a class.
 
 .. code-block:: javascript
 
@@ -239,8 +239,8 @@ class; a block or a single-line comment both work.
     /* stimulusFetch: 'lazy' */
     export default class extends Controller {}
 
-(``// stimulusFetch: 'lazy'`` on the line above the class works too, as does a preserved
-``/*! stimulusFetch: 'lazy' */`` comment: the form tsc and esbuild keep through minification.)
+(``// stimulusFetch: 'lazy'`` works too, and so does a preserved ``/*! stimulusFetch: 'lazy' */`` comment: the form
+tsc and esbuild keep through minification.)
 
 **Third-party UX packages.** Controllers declared in ``controllers.json`` are resolved from ``node_modules``, so
 install them with your package manager, the same as you would with Webpack Encore. For example, with Stimulus and


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | Fix #99
| License        | MIT

While implementing Stimulus support on Symfony Reprise, I wanted to improve things by forcing the comment `/* stimulusFetch: 'lazy' */` to be just above a `class`. 

But the truth is that `/* stimulusFetch: 'lazy' */` controls if the **file** must be lazy-loaded, not the class itself. Which makes sense, but since we are used to use a JSDoc-like notation above `export default class extends Controller`, I made a mistake by forcing the comment to be above the controller class.

With the PR, the code from https://github.com/symfony/recipes/blob/main/symfony/stimulus-bundle/3.3/assets/controllers/csrf_protection_controller.js
```js
/* stimulusFetch: 'lazy' */
export default 'csrf-protection-controller'
```

The regex now matches the marker anywhere in the file, the same way `@symfony/stimulus-bridge` does (it collects comments via acorn) and StimulusBundle's AssetMapper compiler does (a plain regex over the whole file).