### PR TITLE
[Types] Keep the plugin options typed in the published declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
               run: pnpm run fmt:check
             - name: Typecheck
               run: pnpm run typecheck
+            - name: Typecheck built declarations
+              run: pnpm run typecheck:dist
 
     test:
         name: Node ${{ matrix.node-version }} on ${{ matrix.os }}

--- a/assets/package.json
+++ b/assets/package.json
@@ -60,6 +60,7 @@
     "build": "tsdown",
     "dev": "tsdown -w",
     "typecheck": "tsc -p tsconfig.typecheck.json",
+    "typecheck:dist": "tsdown && tsc -p test/fixtures/dist-types/tsconfig.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "prepublishOnly": "tsdown"

--- a/assets/src/index.ts
+++ b/assets/src/index.ts
@@ -1,4 +1,4 @@
-import type { UnpluginFactory } from 'unplugin';
+import type { UnpluginFactory, UnpluginInstance } from 'unplugin';
 import type { RspackStats } from './collectors/rspack';
 import type { CopyResult } from './core/copy';
 import type { BuildContext, ManifestJson, NormalizedGraph, Options } from './types';
@@ -320,6 +320,8 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, _
     };
 };
 
-export const unplugin = /* #__PURE__ */ createUnplugin(unpluginFactory);
+export const unplugin: UnpluginInstance<Options | undefined> = /* #__PURE__ */ createUnplugin<Options | undefined>(
+    unpluginFactory
+);
 
 export default unplugin;

--- a/assets/src/rsbuild.ts
+++ b/assets/src/rsbuild.ts
@@ -1,4 +1,12 @@
+import type { UnpluginInstance } from 'unplugin';
+import type { Options } from './types';
 import { createRsbuildPlugin } from 'unplugin';
 import { unpluginFactory } from '.';
 
-export default createRsbuildPlugin(unpluginFactory);
+// The explicit annotation is what carries `Options` into `dist/*.d.mts`; without it the declaration
+// emit widens the plugin's option parameter to `unknown`/`any` and consumers lose autocompletion.
+const rsbuildPlugin: UnpluginInstance<Options | undefined>['rsbuild'] = createRsbuildPlugin<Options | undefined>(
+    unpluginFactory
+);
+
+export default rsbuildPlugin;

--- a/assets/src/vite.ts
+++ b/assets/src/vite.ts
@@ -1,4 +1,12 @@
+import type { UnpluginInstance } from 'unplugin';
+import type { Options } from './types';
 import { createVitePlugin } from 'unplugin';
 import { unpluginFactory } from '.';
 
-export default createVitePlugin(unpluginFactory);
+// The explicit annotation is what carries `Options` into `dist/*.d.mts`; without it the declaration
+// emit widens the plugin's option parameter to `unknown`/`any` and consumers lose autocompletion.
+const vitePlugin: UnpluginInstance<Options | undefined>['vite'] = createVitePlugin<Options | undefined>(
+    unpluginFactory
+);
+
+export default vitePlugin;

--- a/assets/test/fixtures/dist-types/plugins.ts
+++ b/assets/test/fixtures/dist-types/plugins.ts
@@ -1,0 +1,19 @@
+// Guards the published typings: the declaration emit has silently degraded the options
+// parameter to `unknown`/`any` before, which kills autocompletion in consuming projects.
+
+import SymfonyRsbuild from '../../../dist/rsbuild.mjs';
+import SymfonyVite from '../../../dist/vite.mjs';
+
+SymfonyVite();
+SymfonyVite({ outputPath: 'public/build', publicPath: '/build/', manifestKeyPrefix: 'build/' });
+// @ts-expect-error `outputPath` is a string
+SymfonyVite({ outputPath: 42 });
+// @ts-expect-error unknown option
+SymfonyVite({ nope: true });
+
+SymfonyRsbuild();
+SymfonyRsbuild({ outputPath: 'public/build', publicPath: '/build/', manifestKeyPrefix: 'build/' });
+// @ts-expect-error `outputPath` is a string
+SymfonyRsbuild({ outputPath: 42 });
+// @ts-expect-error unknown option
+SymfonyRsbuild({ nope: true });

--- a/assets/test/fixtures/dist-types/tsconfig.json
+++ b/assets/test/fixtures/dist-types/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "extends": "@tsconfig/node22/tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true
+    },
+    "include": ["plugins.ts"]
+}

--- a/assets/tsconfig.typecheck.json
+++ b/assets/tsconfig.typecheck.json
@@ -8,5 +8,8 @@
         "moduleResolution": "bundler",
         "lib": ["es2024", "esnext.array", "esnext.collection", "es2025.iterator", "dom", "dom.iterable"],
         "noEmit": true
-    }
+    },
+    // Checked separately by `typecheck:dist`: it consumes the built `dist/*.d.mts` under `nodenext`,
+    // the way a published consumer does.
+    "exclude": ["dist", "test/fixtures/dist-types"]
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build": "pnpm -C assets run build",
     "dev": "pnpm -C assets run dev",
     "typecheck": "pnpm -C assets run typecheck",
+    "typecheck:dist": "pnpm -C assets run typecheck:dist",
     "test": "pnpm -C assets run test",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update CHANGELOG.md file -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and CHANGELOG.md files -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Noticed while setuping Reprise on https://github.com/bakslashHQ/baksla.sh/pull/176, I was pretty surprised to see that using `Symfony({})` didn't have any auto-completion for options.
It appears that `vite.d.ts` file was like:
```ts
//#region src/vite.d.ts
declare const _default: (options?: unknown) => import("vite").Plugin<any>[] | import("vite").Plugin<any>;
//#endregion
export { _default as default };
```
which indead does not provide any options. 

With this PR, the `src/vide.d.ts` now looks like:
```ts
import { Options } from "./types.mjs";
import { UnpluginInstance } from "unplugin";
//#region src/vite.d.ts
declare const vitePlugin: UnpluginInstance<Options | undefined>['vite'];
//#endregion
export { vitePlugin as default };
```

which is correct.

I believe this was caused by tsdown and experimental types emitting with TypeScript 7.