### PR TITLE
[Doc] Document the Stimulus application returned by startStimulusApp() and loadControllers()

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -227,6 +227,19 @@ Then start the app from your entry:
 
     const app = startStimulusApp()
 
+**Registering extra controllers.** ``startStimulusApp()`` returns the Stimulus ``Application`` it started, so you
+can keep it and register controllers that are not declared in ``controllers.json`` and do not live in your
+controllers directory, the same way you would with Webpack Encore:
+
+.. code-block:: javascript
+
+    import { startStimulusApp } from '@symfony/reprise/stimulus'
+    import Clipboard from '@stimulus-components/clipboard'
+
+    const app = startStimulusApp()
+
+    app.register('clipboard', Clipboard)
+
 **Local controllers.** Any ``assets/controllers/*_controller.{js,ts}`` is registered automatically. The filename
 becomes the identifier (``hello_controller.js`` becomes ``hello``, ``admin/user_controller.js`` becomes
 ``admin--user``). To load a controller on demand, put a ``stimulusFetch: 'lazy'`` comment anywhere in the file; a


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | Fix #109
| License        | MIT

The Stimulus section captures the return value with `const app = startStimulusApp()`, but no example ever uses `app` and nothing says what it is for. Registering a third-party controller that is not declared in `controllers.json` is the common reason to keep it, so this shows that, using `@stimulus-components/clipboard`.

`loadControllers()` is exported from `@symfony/reprise/stimulus` and appeared nowhere in the documentation. It takes the `Application` plus the eager and lazy collections from `virtual:symfony/controllers`, which is what lets you build the application yourself instead of letting `startStimulusApp()` do it. Both symbols are in the built types (`export { loadControllers, startStimulusApp }` in `dist/stimulus.d.mts`), so this documents public API rather than an internal helper.
