### PR TITLE
[StyleEntries] Correctly ship style entries as CSS only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.1.3
+
+- Properly support CSS entries: an entry pointing straight at a stylesheet builds to CSS only, with no `<script>` tag and no JavaScript file listed in `entrypoints.json` or `manifest.json`
+
 ## 1.1.0
 
 - Add support for the top-level `input` option in dev mode, added in Vite 8.2

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 Symfony Reprise covers only the Symfony-side glue the bundlers leave out:
 
 - 🎯 **Multiple entries**: build several independent entry points from one config
+- 🎨 **Style entries**: point an entry straight at a `.scss`/`.css` file and get CSS only, no stray `<script>`
 - 📄 **`entrypoints.json`**: generated in both build and dev-server modes
 - 🗺️ **`manifest.json`**: maps each logical filename to its hashed URL
 - 🔖 **Asset versioning**: content-hash cache busting, wired into the manifest

--- a/assets/src/collectors/rspack.ts
+++ b/assets/src/collectors/rspack.ts
@@ -1,16 +1,12 @@
 import type { AssetEntry, EntryFiles, NormalizedGraph } from '../types';
 import { extname } from 'node:path';
+import { isStylesheet, stripUrlSuffix } from '../core/paths';
 
 /** Minimal subset of the Rspack/webpack stats JSON (from `compilation.getStats().toJson(...)`). */
 export interface RspackStats {
     entrypoints?: Record<string, { assets?: { name: string }[] }>;
     assetsByChunkName?: Record<string, string[]>;
     assets?: { name: string; info?: { sourceFilename?: string } }[];
-}
-
-// Rspack keeps the `url()` query/fragment (`./x.woff2?v=1`) in `sourceFilename`, Vite doesn't.
-function stripUrlSuffix(name: string): string {
-    return name.replace(/[?#].*$/, '');
 }
 
 function fileExt(name: string): string {
@@ -21,14 +17,32 @@ function isHotUpdate(name: string): boolean {
     return name.includes('.hot-update.');
 }
 
-export function statsToGraph(stats: RspackStats): NormalizedGraph {
+/** Rspack's normalized `compiler.options.entry` (`EntryStaticNormalized`): entry name -> its source imports. */
+export type RspackEntry = Record<string, { import?: string[] }>;
+
+/**
+ * Entries built purely from stylesheets (`{ theme: 'theme.scss' }`). Rspack always emits a runtime-only JS
+ * file for them, where Vite prunes its equivalent; hiding it on both sides matches Encore's `addStyleEntry`,
+ * which shipped CSS and no `<script>`. The file itself stays on disk, simply unreferenced.
+ */
+export function styleEntryNames(entry: RspackEntry | undefined): Set<string> {
+    const names = new Set<string>();
+    for (const [name, { import: sources = [] }] of Object.entries(entry ?? {})) {
+        if (sources.length > 0 && sources.every(isStylesheet)) names.add(name);
+    }
+    return names;
+}
+
+export function statsToGraph(stats: RspackStats, entryConfig?: RspackEntry): NormalizedGraph {
+    const styleEntries = styleEntryNames(entryConfig);
     const entryPoints: Record<string, EntryFiles> = {};
     for (const [name, entry] of Object.entries(stats.entrypoints ?? {})) {
         const files: EntryFiles = { js: [], css: [], preload: [], dynamic: [] };
+        const styleEntry = styleEntries.has(name);
         for (const asset of entry.assets ?? []) {
             if (isHotUpdate(asset.name)) continue;
             const ext = fileExt(asset.name);
-            if (ext === 'js') files.js.push(asset.name);
+            if (ext === 'js' && !styleEntry) files.js.push(asset.name);
             else if (ext === 'css') files.css.push(asset.name);
         }
         entryPoints[name] = files;
@@ -36,9 +50,12 @@ export function statsToGraph(stats: RspackStats): NormalizedGraph {
 
     const assets: AssetEntry[] = [];
     for (const [chunkName, files] of Object.entries(stats.assetsByChunkName ?? {})) {
+        const styleEntry = styleEntries.has(chunkName);
         for (const fileName of files) {
             if (isHotUpdate(fileName)) continue;
-            assets.push({ logicalName: `${chunkName}.${fileExt(fileName)}`, fileName });
+            const ext = fileExt(fileName);
+            if (ext === 'js' && styleEntry) continue;
+            assets.push({ logicalName: `${chunkName}.${ext}`, fileName });
         }
     }
     for (const asset of stats.assets ?? []) {

--- a/assets/src/collectors/vite.ts
+++ b/assets/src/collectors/vite.ts
@@ -1,7 +1,7 @@
 import type { Rollup } from 'vite';
 import type { AssetEntry, EntryFiles, NormalizedGraph } from '../types';
-import { extname, relative, resolve } from 'node:path';
-import { slash } from '../core/paths';
+import { relative, resolve } from 'node:path';
+import { isStylesheet, slash } from '../core/paths';
 
 interface ViteChunkMetadata {
     importedCss: Set<string>;
@@ -25,13 +25,16 @@ export function bundleToGraph(bundle: Rollup.OutputBundle, root: string): Normal
             // facade. Walk static imports so entry CSS is collected wherever Rollup parked it.
             const css = collectEntryCss(chunk, bundle);
             for (const name of css) entryCss.add(name);
+            // Vite drops a style entry's empty JS chunk from the bundle *after* this hook, so advertising it
+            // would render a `<script>` for a file that was never written (and break SRI, which hashes off disk).
+            const styleEntry = isStylesheet(chunk.facadeModuleId);
             entryPoints[chunk.name] = {
-                js: [chunk.fileName],
+                js: styleEntry ? [] : [chunk.fileName],
                 css,
                 preload: emittedChunks(chunk.imports, bundle),
                 dynamic: emittedChunks(chunk.dynamicImports, bundle),
             };
-            assets.push({ logicalName: `${chunk.name}.js`, fileName: chunk.fileName });
+            if (!styleEntry) assets.push({ logicalName: `${chunk.name}.js`, fileName: chunk.fileName });
         } else if (chunk.viteMetadata) {
             for (const name of chunk.viteMetadata.importedCss) asyncCss.add(name);
         }
@@ -86,8 +89,6 @@ function assetLogicalName(file: Rollup.OutputAsset, root: string, entryCss: Set<
     return file.names[0] ?? file.fileName;
 }
 
-const CSS_EXTS = new Set(['.css', '.scss', '.sass', '.less', '.styl', '.stylus', '.postcss', '.pcss']);
-
 export interface DevConfig {
     root: string;
     input?: Rollup.InputOption;
@@ -107,7 +108,7 @@ export function configToDevGraph(config: DevConfig): NormalizedGraph {
 
     for (const [name, inputPath] of Object.entries(entries)) {
         const rel = slash(relative(config.root, resolve(config.root, inputPath)));
-        const type: 'js' | 'css' = CSS_EXTS.has(extname(inputPath)) ? 'css' : 'js';
+        const type: 'js' | 'css' = isStylesheet(inputPath) ? 'css' : 'js';
         const files: EntryFiles = { js: [], css: [], preload: [], dynamic: [] };
         files[type] = [rel];
         entryPoints[name] = files;

--- a/assets/src/core/paths.ts
+++ b/assets/src/core/paths.ts
@@ -1,3 +1,5 @@
+import { extname } from 'node:path';
+
 /** Normalize Windows backslash separators to forward slashes (portable URLs and ESM specifiers). */
 export function slash(p: string): string {
     return p.replace(/\\/g, '/');
@@ -6,4 +8,20 @@ export function slash(p: string): string {
 /** Drop a single trailing slash, e.g. when composing a dev-server origin with a public path. */
 export function trimTrailingSlash(s: string): string {
     return s.replace(/\/$/, '');
+}
+
+/** Drop a `url()` query/fragment (`./x.woff2?v=1`): Rspack keeps it in `sourceFilename`, Vite doesn't. */
+export function stripUrlSuffix(name: string): string {
+    return name.replace(/[?#].*$/, '');
+}
+
+const STYLESHEET_EXTS = new Set(['.css', '.scss', '.sass', '.less', '.styl', '.stylus', '.postcss', '.pcss']);
+
+/**
+ * True when the path is a stylesheet source, so an entry pointing at it is a *style entry* (Encore's
+ * `addStyleEntry`): it compiles to CSS only and must not advertise a JS file.
+ */
+export function isStylesheet(path: string | null | undefined): boolean {
+    if (!path) return false;
+    return STYLESHEET_EXTS.has(extname(stripUrlSuffix(path)).toLowerCase());
 }

--- a/assets/src/index.ts
+++ b/assets/src/index.ts
@@ -1,12 +1,12 @@
 import type { UnpluginFactory, UnpluginInstance } from 'unplugin';
-import type { RspackStats } from './collectors/rspack';
+import type { RspackEntry, RspackStats } from './collectors/rspack';
 import type { CopyResult } from './core/copy';
 import type { BuildContext, ManifestJson, NormalizedGraph, Options } from './types';
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import * as process from 'node:process';
 import { createUnplugin } from 'unplugin';
-import { statsToGraph } from './collectors/rspack';
+import { statsToGraph, styleEntryNames } from './collectors/rspack';
 import { bundleToGraph, configToDevGraph } from './collectors/vite';
 import { copyManifest, resolveCopyFiles, writeCopyFiles } from './core/copy';
 import { resolveDevOrigin } from './core/dev-server';
@@ -259,6 +259,29 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, _
                                     }
                                 );
                             });
+                            // Rspack emits a runtime-only JS file for a style entry; delete it so the build
+                            // matches Vite, which prunes its equivalent. Dev keeps it: nothing reaches the disk
+                            // there, and the file carries the entry's HMR runtime.
+                            const styleEntries = styleEntryNames(c.options.entry as RspackEntry);
+                            c.hooks.thisCompilation.tap('@symfony/reprise:style-entries', (compilation) => {
+                                compilation.hooks.processAssets.tap(
+                                    {
+                                        name: '@symfony/reprise:style-entries',
+                                        stage: c.rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+                                    },
+                                    () => {
+                                        for (const chunk of compilation.chunks) {
+                                            if (!chunk.name || !styleEntries.has(chunk.name)) continue;
+                                            for (const file of chunk.files) {
+                                                if (file.endsWith('.js')) compilation.deleteAsset(file);
+                                            }
+                                            for (const file of chunk.auxiliaryFiles) {
+                                                if (file.endsWith('.js.map')) compilation.deleteAsset(file);
+                                            }
+                                        }
+                                    }
+                                );
+                            });
                         }
 
                         c.hooks.done.tap('@symfony/reprise', (stats) => {
@@ -284,7 +307,10 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, _
                                 manifestKeyPrefix: resolved.manifestKeyPrefix,
                             };
                             const graph = statsToGraph(
-                                stats.toJson({ assets: true, entrypoints: true }) as RspackStats
+                                stats.toJson({ assets: true, entrypoints: true }) as RspackStats,
+                                // The normalized entry rather than `source.entry`: Rsbuild resolves and reshapes
+                                // entries on the way to Rspack, and this is the form the stats keys match.
+                                c.options.entry as RspackEntry
                             );
                             // SRI (build only): `done` fires after emit, so hash files off disk. Dev has no stable hashes.
                             if (!isDev && resolved.integrity) {

--- a/assets/test/collectors/rspack.test.ts
+++ b/assets/test/collectors/rspack.test.ts
@@ -59,3 +59,42 @@ describe('statsToGraph', () => {
         expect(graph.entryPoints.app.css).toEqual(['app.b2.css#frag']);
     });
 });
+
+describe('statsToGraph with style entries', () => {
+    const stats = {
+        entrypoints: {
+            theme: { assets: [{ name: 'theme.a1.js' }, { name: 'theme.b2.css' }] },
+            mixed: { assets: [{ name: 'mixed.c3.js' }, { name: 'mixed.d4.css' }] },
+            empty: { assets: [{ name: 'empty.e5.js' }] },
+        },
+        assetsByChunkName: {
+            theme: ['theme.a1.js', 'theme.b2.css'],
+            mixed: ['mixed.c3.js', 'mixed.d4.css'],
+            empty: ['empty.e5.js'],
+        },
+    };
+    const entryConfig = {
+        theme: { import: ['/app/assets/styles/theme.scss'] },
+        mixed: { import: ['/app/assets/admin.js', '/app/assets/admin.scss'] },
+        empty: { import: [] },
+    };
+
+    it('drops the runtime-only js of a stylesheet entry from the entry and the manifest', () => {
+        const graph = statsToGraph(stats, entryConfig);
+        expect(graph.entryPoints.theme).toEqual({ js: [], css: ['theme.b2.css'], preload: [], dynamic: [] });
+        expect(graph.assets).toContainEqual({ logicalName: 'theme.css', fileName: 'theme.b2.css' });
+        expect(graph.assets).not.toContainEqual({ logicalName: 'theme.js', fileName: 'theme.a1.js' });
+    });
+
+    it('keeps the js of entries not built purely from stylesheets', () => {
+        const graph = statsToGraph(stats, entryConfig);
+        expect(graph.entryPoints.mixed.js).toEqual(['mixed.c3.js']);
+        expect(graph.entryPoints.empty.js).toEqual(['empty.e5.js']);
+    });
+
+    it('keeps every js when no entry config is available', () => {
+        const graph = statsToGraph(stats);
+        expect(graph.entryPoints.theme.js).toEqual(['theme.a1.js']);
+        expect(graph.assets).toContainEqual({ logicalName: 'theme.js', fileName: 'theme.a1.js' });
+    });
+});

--- a/assets/test/collectors/vite.test.ts
+++ b/assets/test/collectors/vite.test.ts
@@ -47,6 +47,49 @@ describe('bundleToGraph', () => {
         expect(graph.entryPoints.vendor).toBeUndefined();
     });
 
+    it('advertises no js for a style entry (Vite prunes its empty chunk)', () => {
+        const bundle = {
+            'theme-a1b2.js': {
+                ...chunk({
+                    fileName: 'theme-a1b2.js',
+                    name: 'theme',
+                    isEntry: true,
+                    code: '',
+                    facadeModuleId: '/app/assets/styles/theme.scss',
+                }),
+                viteMetadata: { importedCss: new Set(['theme-c3.css']), importedAssets: new Set() },
+            },
+            'theme-c3.css': asset('theme-c3.css', ['theme.css']),
+        } as unknown as Rollup.OutputBundle;
+
+        const graph = bundleToGraph(bundle, '/app');
+
+        expect(graph.entryPoints.theme).toEqual({ js: [], css: ['theme-c3.css'], preload: [], dynamic: [] });
+        expect(graph.assets).toEqual([{ logicalName: 'theme.css', fileName: 'theme-c3.css' }]);
+    });
+
+    it('keeps the js of an entry that merely imports CSS', () => {
+        // Vite only prunes a *stylesheet-sourced* entry; a .js entry importing nothing but CSS is still written.
+        const bundle = {
+            'app-a1b2.js': {
+                ...chunk({
+                    fileName: 'app-a1b2.js',
+                    name: 'app',
+                    isEntry: true,
+                    code: '',
+                    facadeModuleId: '/app/assets/app.js',
+                }),
+                viteMetadata: { importedCss: new Set(['app-c3.css']), importedAssets: new Set() },
+            },
+            'app-c3.css': asset('app-c3.css', ['app.css']),
+        } as unknown as Rollup.OutputBundle;
+
+        const graph = bundleToGraph(bundle, '/app');
+
+        expect(graph.entryPoints.app).toEqual({ js: ['app-a1b2.js'], css: ['app-c3.css'], preload: [], dynamic: [] });
+        expect(graph.assets).toContainEqual({ logicalName: 'app.js', fileName: 'app-a1b2.js' });
+    });
+
     it('drops a CSS-only dynamic import whose chunk was pruned to empty JS', () => {
         // `import('x.css')` yields a chunk rolldown-vite empties (code === '') and never writes; its name
         // still shows in dynamicImports. It must be dropped, and its async CSS kept out of the manifest.

--- a/assets/test/fixtures/css-modules/app.js
+++ b/assets/test/fixtures/css-modules/app.js
@@ -1,0 +1,3 @@
+import styles from './card.module.css'
+
+document.body.className = styles.badge

--- a/assets/test/fixtures/css-modules/card.module.css
+++ b/assets/test/fixtures/css-modules/card.module.css
@@ -1,0 +1,3 @@
+.badge {
+    color: rebeccapurple;
+}

--- a/assets/test/fixtures/style-entry/app.js
+++ b/assets/test/fixtures/style-entry/app.js
@@ -1,0 +1,1 @@
+console.log('app')

--- a/assets/test/fixtures/style-entry/theme.css
+++ b/assets/test/fixtures/style-entry/theme.css
@@ -1,0 +1,1 @@
+body { color: rebeccapurple; }

--- a/assets/test/integration/css-modules.test.ts
+++ b/assets/test/integration/css-modules.test.ts
@@ -1,0 +1,77 @@
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRsbuild } from '@rsbuild/core';
+import { build } from 'vite';
+import { describe, expect, it } from 'vitest';
+import SymfonyRsbuild from '../../src/rsbuild';
+import SymfonyVite from '../../src/vite';
+
+// The other side of `style-entry.test.ts`: a CSS Module imported *from* a JS entry, which is how CSS Modules
+// are meant to be used. The entry keeps its script (it carries the class-name mapping) and the extracted CSS
+// joins its `css` bucket, exactly like a plain stylesheet import.
+const fixture = join(import.meta.dirname, '../fixtures/css-modules');
+const input = { app: join(fixture, 'app.js') };
+
+interface Entrypoints {
+    entryPoints: Record<string, { js: string[]; css: string[] }>;
+}
+
+function readEmitted(out: string, url: string): string {
+    return readFileSync(join(out, url.replace(/^build\//, '')), 'utf8');
+}
+
+function expectScopedBadge(out: string, entrypoints: Entrypoints): void {
+    const css = readEmitted(out, entrypoints.entryPoints.app.css[0]);
+    // Both bundlers rewrite `.badge` to a generated name; only the mangling proves CSS Modules ran at all.
+    expect(css).not.toMatch(/\.badge[\s,{]/);
+    expect(css).toMatch(/#639|rebeccapurple/);
+
+    const generated = css.match(/\.([\w-]+)\s*\{/)?.[1];
+    expect(generated).toBeTruthy();
+    // The mapping is what makes the entry script worth loading, so the same name must reach the JS.
+    expect(readEmitted(out, entrypoints.entryPoints.app.js[0])).toContain(generated);
+}
+
+describe('CSS Modules imported from a JS entry (Vite/Rsbuild parity)', () => {
+    it('vite keeps the entry js and lists the scoped css', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-cssmod-vite-'));
+        await build({
+            root: fixture,
+            logLevel: 'silent',
+            build: { emptyOutDir: true, rollupOptions: { input } },
+            plugins: [SymfonyVite({ outputPath: out, publicPath: '/build/' })],
+        });
+
+        const entrypoints: Entrypoints = JSON.parse(readFileSync(join(out, 'entrypoints.json'), 'utf8'));
+        expect(entrypoints.entryPoints.app.js).toHaveLength(1);
+        expect(entrypoints.entryPoints.app.css).toHaveLength(1);
+        expectScopedBadge(out, entrypoints);
+
+        const manifest = JSON.parse(readFileSync(join(out, 'manifest.json'), 'utf8'));
+        expect(manifest['build/app.js']).toMatch(/\.js$/);
+        expect(manifest['build/app.css']).toMatch(/\.css$/);
+    }, 30_000);
+
+    it('rsbuild keeps the entry js and lists the scoped css', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-cssmod-rsbuild-'));
+        const rsbuild = await createRsbuild({
+            cwd: fixture,
+            rsbuildConfig: {
+                mode: 'production',
+                source: { entry: input },
+                plugins: [SymfonyRsbuild({ outputPath: out, publicPath: '/build/' })],
+            },
+        });
+        await rsbuild.build();
+
+        const entrypoints: Entrypoints = JSON.parse(readFileSync(join(out, 'entrypoints.json'), 'utf8'));
+        expect(entrypoints.entryPoints.app.js).toHaveLength(1);
+        expect(entrypoints.entryPoints.app.css).toHaveLength(1);
+        expectScopedBadge(out, entrypoints);
+
+        const manifest = JSON.parse(readFileSync(join(out, 'manifest.json'), 'utf8'));
+        expect(manifest['build/app.js']).toMatch(/\.js$/);
+        expect(manifest['build/app.css']).toMatch(/\.css$/);
+    }, 60_000);
+});

--- a/assets/test/integration/style-entry.test.ts
+++ b/assets/test/integration/style-entry.test.ts
@@ -1,0 +1,82 @@
+import { existsSync, mkdtempSync, readdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRsbuild } from '@rsbuild/core';
+import { build } from 'vite';
+import { describe, expect, it } from 'vitest';
+import { referencedFileNames } from '../../src/core/integrity';
+import SymfonyRsbuild from '../../src/rsbuild';
+import SymfonyVite from '../../src/vite';
+
+// A *style entry* — an entry pointing straight at a stylesheet (`{ theme: 'theme.scss' }`), Encore's
+// `addStyleEntry` — compiles to CSS and nothing else. Vite drops the empty JS chunk it produces, so any
+// reference to it is a 404 (and SRI, which hashes entry files off disk, throws ENOENT); Rspack emits a
+// runtime-only JS file, which the plugin deletes from the build. Both must advertise CSS only. `.css` here
+// because sass isn't a test dependency; the rule is the file extension, so `.scss` follows the same path.
+const fixture = join(import.meta.dirname, '../fixtures/style-entry');
+const input = { app: join(fixture, 'app.js'), theme: join(fixture, 'theme.css') };
+
+function jsFilesOnDisk(dir: string): string[] {
+    return readdirSync(dir, { recursive: true, withFileTypes: true })
+        .filter((entry) => entry.isFile() && entry.name.endsWith('.js'))
+        .map((entry) => entry.name);
+}
+
+describe('style entries advertise CSS only (Vite/Rsbuild parity)', () => {
+    it('vite emits no js for the style entry, and SRI survives', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-style-vite-'));
+        await build({
+            root: fixture,
+            logLevel: 'silent',
+            build: { emptyOutDir: true, rollupOptions: { input } },
+            plugins: [SymfonyVite({ outputPath: out, publicPath: '/build/', integrity: { enabled: true } })],
+        });
+
+        const entrypoints = JSON.parse(readFileSync(join(out, 'entrypoints.json'), 'utf8'));
+        expect(entrypoints.entryPoints.theme.js).toEqual([]);
+        expect(entrypoints.entryPoints.theme.css).toHaveLength(1);
+
+        // Every file we advertise must exist on disk — the regression this pins.
+        for (const ref of referencedFileNames(entrypoints.entryPoints)) {
+            expect(existsSync(join(out, ref.replace(/^build\//, '')))).toBe(true);
+            expect(entrypoints.integrity[ref]).toMatch(/^sha384-/);
+        }
+
+        // Vite never wrote the style entry's chunk, so the app entry's is the only JS in the build.
+        expect(jsFilesOnDisk(out)).toHaveLength(1);
+
+        // The normal entry is untouched.
+        expect(entrypoints.entryPoints.app.js).toHaveLength(1);
+
+        const manifest = JSON.parse(readFileSync(join(out, 'manifest.json'), 'utf8'));
+        expect(manifest['build/theme.css']).toMatch(/\.css$/);
+        expect(manifest['build/theme.js']).toBeUndefined();
+        expect(manifest['build/app.js']).toMatch(/\.js$/);
+    }, 30_000);
+
+    it('rsbuild deletes the runtime-only js of the style entry', async () => {
+        const out = mkdtempSync(join(tmpdir(), 'ups-style-rsbuild-'));
+        const rsbuild = await createRsbuild({
+            cwd: fixture,
+            rsbuildConfig: {
+                mode: 'production',
+                source: { entry: input },
+                plugins: [SymfonyRsbuild({ outputPath: out, publicPath: '/build/' })],
+            },
+        });
+        await rsbuild.build();
+
+        const entrypoints = JSON.parse(readFileSync(join(out, 'entrypoints.json'), 'utf8'));
+        expect(entrypoints.entryPoints.theme.js).toEqual([]);
+        expect(entrypoints.entryPoints.theme.css).toHaveLength(1);
+        expect(entrypoints.entryPoints.app.js).toHaveLength(1);
+
+        // Deleted from the compilation, so the app entry's is the only JS in the build.
+        expect(jsFilesOnDisk(out)).toHaveLength(1);
+
+        const manifest = JSON.parse(readFileSync(join(out, 'manifest.json'), 'utf8'));
+        expect(manifest['build/theme.css']).toMatch(/\.css$/);
+        expect(manifest['build/theme.js']).toBeUndefined();
+        expect(manifest['build/app.js']).toMatch(/\.js$/);
+    }, 60_000);
+});

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,6 +14,7 @@ Vite and Rsbuild already handle **Sass/Less/PostCSS**, **TypeScript**, **JSX/Vue
 reimplement any of that. It covers only the Symfony-side glue the bundlers leave out:
 
 - **Multiple entries**: build several independent entry points from one config
+- **Style entries**: point an entry straight at a ``.scss``/``.css`` file and get CSS only, no stray ``<script>``
 - ``entrypoints.json``: generated in both build and dev-server modes
 - ``manifest.json``: maps each logical filename to its hashed URL
 - **Asset versioning**: content-hash cache busting, wired into the manifest
@@ -279,6 +280,48 @@ Map, for instance, ships a CSS file meant for Webpack's loader and needs an alia
     })
 
 Check each package's own docs for this kind of tweak.
+
+Style entries
+~~~~~~~~~~~~~
+
+An entry can point straight at a stylesheet, the way Encore's ``addStyleEntry()`` did. It compiles to CSS and
+nothing else: ``reprise_entry_link_tags('theme')`` renders the ``<link>``, while ``reprise_entry_script_tags('theme')``
+has nothing to render (in dev it still emits the shared HMR client, once per page).
+
+.. code-block:: javascript
+
+    // vite.config.ts
+    export default defineConfig({
+      input: {
+        app: './assets/app.js',
+        theme: './assets/styles/theme.scss',
+      },
+      plugins: [
+        Symfony(),
+      ],
+    })
+
+.. code-block:: javascript
+
+    // rsbuild.config.ts
+    export default defineConfig({
+      source: {
+        entry: {
+          app: './assets/app.js',
+          theme: './assets/styles/theme.scss',
+        },
+      },
+      plugins: [
+        pluginSass(),
+        Symfony(),
+      ],
+    })
+
+Reprise treats an entry as a style entry when its source file carries a stylesheet extension: ``.css``, ``.scss``,
+``.sass``, ``.less``, ``.styl``, ``.stylus``, ``.postcss`` or ``.pcss``. Both bundlers still produce a JavaScript file
+for it internally, but neither keeps it: Vite prunes it before writing the build, and Reprise deletes Rspack's from
+the compilation. Either way, it stays out of ``entrypoints.json`` and ``manifest.json``: no empty ``<script>`` tag
+ever reaches the page.
 
 File copy
 ~~~~~~~~~
@@ -723,7 +766,7 @@ Webpack Encore                                                                  
 ``enableSingleRuntimeChunk()`` / ``disableSingleRuntimeChunk()``                     native runtime chunk management
 ``enableSourceMaps()``                                                               native (Vite ``build.sourcemap``)
 ``configureImageRule()`` / ``configureFontRule()`` / ``configureFilenames()``        native asset handling and output naming
-``addStyleEntry()``                                                                  add the stylesheet as an entry input, or import it from a JS entry
+``addStyleEntry()``                                                                  add the stylesheet as an entry input (see `Style entries`_), or import it from a JS entry
 ``configureDefinePlugin()``                                                          Vite ``define``, Rsbuild ``source.define``
 ``disableCssExtraction()`` / ``configureCssLoader()`` / ``configureStyleLoader()``   native CSS handling (extraction, minification)
 ``addAliases()``                                                                     ``resolve.alias``

--- a/playground/assets/controllers/card_module_controller.js
+++ b/playground/assets/controllers/card_module_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from '@hotwired/stimulus';
+import styles from '../styles/card.module.scss';
+
+export default class extends Controller {
+    connect() {
+        this.element.classList.add(styles.badge);
+    }
+}

--- a/playground/assets/styles/card.module.scss
+++ b/playground/assets/styles/card.module.scss
@@ -1,0 +1,16 @@
+// A CSS Module: `badge` is hashed at build time, so no template can name it. `card_module_controller.js`
+// imports the mapping and applies `styles.badge` at runtime.
+$accent: #0f766e;
+
+.badge {
+    display: inline-block;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    font-weight: 600;
+    color: #fff;
+    background: $accent;
+
+    &::before {
+        content: '● ';
+    }
+}

--- a/playground/assets/styles/theme.scss
+++ b/playground/assets/styles/theme.scss
@@ -1,0 +1,16 @@
+// A *style entry*: `theme` is registered as an entry pointing straight at this file, with no JS behind it
+// (Encore's `addStyleEntry`). Scoped to `.theme-card` so the page-specific entry never repaints other pages.
+$accent: #7c3aed;
+$accent-strong: #5b21b6;
+
+.theme-card {
+    padding: 1.25rem;
+    border-radius: 12px;
+    border: 2px dashed rgba($accent, 0.5);
+    background: rgba($accent, 0.08);
+    color: $accent;
+
+    strong {
+        color: $accent-strong;
+    }
+}

--- a/playground/rsbuild.config.ts
+++ b/playground/rsbuild.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
     entry: {
       app: resolve(__dirname, './assets/app.ts'),
       admin: resolve(__dirname, './assets/admin.ts'),
+      // A style entry: a stylesheet as the entry input, so it builds to CSS with no JS attached.
+      theme: resolve(__dirname, './assets/styles/theme.scss'),
     },
   },
   plugins: [

--- a/playground/templates/feature/scss-typescript.html.twig
+++ b/playground/templates/feature/scss-typescript.html.twig
@@ -1,8 +1,26 @@
 {% extends 'page.html.twig' %}
 
+{% block stylesheets %}
+    {{ parent() }}
+    {{ reprise_entry_link_tags('theme') }}
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    {# A style entry has no JavaScript, so this renders nothing at all. #}
+    {{ reprise_entry_script_tags('theme') }}
+{% endblock %}
+
 {% block content %}
     <twig:Panel>
         <p>The <code>app</code> entry is <code>assets/app.ts</code> (TypeScript); its styling is <strong>Tailwind CSS v4</strong> (<code>@import "tailwindcss"</code>), compiled by each bundler's official plugin: <code>@tailwindcss/vite</code> for Vite, <code>@rsbuild/plugin-tailwindcss</code> for Rsbuild.</p>
         <p>The <code>admin</code> entry keeps a <code>.scss</code> file (Sass variables + nesting) so Sass is exercised too. Reprise compiles none of this: the bundlers handle TypeScript, Tailwind, and Sass (via <code>sass-embedded</code> and <code>@rsbuild/plugin-sass</code>) natively.</p>
     </twig:Panel>
+
+    <div class="theme-card">
+        <p><strong>Style entry.</strong> The card you are looking at is styled by <code>theme</code>, an entry that points straight at <code>assets/styles/theme.scss</code> with no JavaScript behind it (Webpack Encore called this <code>addStyleEntry()</code>). This page calls both <code>reprise_entry_link_tags('theme')</code> and <code>reprise_entry_script_tags('theme')</code>: the first renders the <code>&lt;link&gt;</code>, the second renders nothing, because a style entry has no JS to load.</p>
+    </div>
+
+    <p class="mt-4 text-slate-500">The other way round, a <strong>CSS Module</strong>: <code>assets/styles/card.module.scss</code> is imported by <code>card_module_controller.js</code>, which rides along in the <code>app</code> entry. Its class name is hashed at build time, so no template can spell it out — the controller applies <code>styles.badge</code> when the element connects. Inspect the badge below and you'll see the generated name.</p>
+    <p class="mt-3"><span data-controller="card-module">Scoped by a CSS Module</span></p>
 {% endblock %}

--- a/playground/tests/e2e/styling.test.ts
+++ b/playground/tests/e2e/styling.test.ts
@@ -1,0 +1,57 @@
+import { type Browser, chromium } from 'playwright'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { expectNoErrors, withPage } from './support'
+
+let browser: Browser
+
+beforeAll(async () => {
+  browser = await chromium.launch()
+})
+
+afterAll(async () => {
+  await browser?.close()
+})
+
+describe('stylesheet plumbing on /feature/scss-typescript', () => {
+  test('the theme style entry renders a <link> and no <script>', async () => {
+    await withPage(browser, async ({ page, errors }) => {
+      await page.goto('/feature/scss-typescript', { waitUntil: 'load' })
+
+      const hrefs = await page.locator('link[rel=stylesheet]').evaluateAll((links) =>
+        links.map((link) => (link as HTMLLinkElement).href),
+      )
+      expect(hrefs.filter((href) => href.includes('theme'))).toHaveLength(1)
+
+      const sources = await page.locator('script[src]').evaluateAll((scripts) =>
+        scripts.map((script) => (script as HTMLScriptElement).src),
+      )
+      expect(sources.filter((src) => src.includes('theme'))).toEqual([])
+
+      // #7c3aed, straight from theme.scss: the entry's CSS really landed.
+      const colour = await page.locator('.theme-card').evaluate((el) => getComputedStyle(el).color)
+      expect(colour).toBe('rgb(124, 58, 237)')
+
+      expectNoErrors(errors)
+    })
+  })
+
+  test('a CSS Module class is hashed and applied by its controller', async () => {
+    await withPage(browser, async ({ page, errors }) => {
+      await page.goto('/feature/scss-typescript', { waitUntil: 'load' })
+
+      // The class attribute only appears once the Stimulus controller has applied the generated name.
+      const badge = page.locator('[data-controller="card-module"][class]')
+      await badge.waitFor({ state: 'visible', timeout: 5_000 })
+
+      const className = (await badge.getAttribute('class')) ?? ''
+      expect(className).not.toBe('badge')
+      expect(className).not.toBe('')
+
+      // #0f766e, from card.module.scss.
+      const background = await badge.evaluate((el) => getComputedStyle(el).backgroundColor)
+      expect(background).toBe('rgb(15, 118, 110)')
+
+      expectNoErrors(errors)
+    })
+  })
+})

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -14,6 +14,8 @@ const publicPath = process.env.CDN_BASE ?? '/build/'
 const input = {
   app: resolve(__dirname, './assets/app.ts'),
   admin: resolve(__dirname, './assets/admin.ts'),
+  // A style entry: a stylesheet as the entry input, so it builds to CSS with no JS attached.
+  theme: resolve(__dirname, './assets/styles/theme.scss'),
 }
 
 // The top-level `input` option landed in Vite 8.2; the E2E matrix still runs Vite 7.


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | –
| License        | MIT

A *style entry* is an entry that points straight at a stylesheet, Encore's `addStyleEntry()`. Reprise already presented it as supported (the migration table maps `addStyleEntry()` to "add the stylesheet as an entry input") and dev mode already handled it, since `configToDevGraph()` types entries by extension. The build path never got the same treatment.

```js
// vite.config.ts
input: {
  app: './assets/app.js',
  theme: './assets/styles/theme.scss',
}
```

Under Vite, such an entry compiles to an empty JS chunk that Vite prunes in its own post-ordered `generateBundle`, after ours has already recorded it. The file is never written, so the rendered `<script>` 404s, `manifest.json` gains a dead `build/theme.js` key, and with `integrity` enabled the build fails outright, because SRI hashes entry files off disk.

```
Error: ENOENT: no such file or directory, open '…/theme-Dop8L6co.js'
    at integrityFromDisk (src/core/integrity.ts:30)
```

Under Rsbuild, Rspack always emits the entry JS, so nothing 404s, but the entry advertises a runtime-only file: a pointless `<script>` and the same dead manifest key.

The fix makes an entry whose sources are all stylesheets advertise CSS only, in both `entrypoints.json` and `manifest.json`, on both bundlers, using the same file-extension rule dev mode already relied on, so dev and build now agree. On Rsbuild the runtime-only file is also deleted from the build, the way Encore's `DeleteUnusedEntriesJSPlugin` did; this is build only, since in dev nothing reaches disk and that file carries the entry's HMR runtime.
